### PR TITLE
chore: fixed simplification of types removed primitives

### DIFF
--- a/src/simplification/Simplify.ts
+++ b/src/simplification/Simplify.ts
@@ -13,7 +13,10 @@ export function simplify(schema : Schema | boolean) : CommonModel[] {
   let models : CommonModel[] = [];
   let model = new CommonModel();
   model.originalSchema = Schema.toSchema(schema);
-  model.type = simplifyTypes(schema);
+  const simplifiedTypes = simplifyTypes(schema);
+  if(simplifiedTypes !== undefined){
+    model.type = simplifiedTypes;
+  }
   if(typeof schema !== "boolean"){
     //All schemas of type object MUST have ids, for now lets make it simple
     if(model.type !== undefined && model.type.includes("object")){

--- a/src/simplification/Simplify.ts
+++ b/src/simplification/Simplify.ts
@@ -19,7 +19,7 @@ export function simplify(schema : Schema | boolean) : CommonModel[] {
   }
   if(typeof schema !== "boolean"){
     //All schemas of type object MUST have ids, for now lets make it simple
-    if(model.type !== undefined && model.type.includes("object")){
+    if(model.type !== undefined && (model.type === "object" || model.type.includes("object"))){
       let schemaId = schema.$id ? schema.$id : `anonymSchema${anonymCounter++}`;
       if(typeof schema !== "boolean"){
         schema.$id = schemaId;

--- a/src/simplification/SimplifyTypes.ts
+++ b/src/simplification/SimplifyTypes.ts
@@ -17,20 +17,21 @@ export default function simplifyTypes(schema: Schema | boolean) : string[] | str
   }
   let types : string[] | string | undefined = undefined;
   const addToTypes = (typesToCheck: string[] | string | undefined) => {
-    if(typesToCheck === undefined) return;
-    if(types === undefined){
-      types = typesToCheck;
-    } else {
-      if(Array.isArray(typesToCheck)){
-        typesToCheck.forEach(addToTypes);
-      }else{
-        if(Array.isArray(types)){
-          if(!types.includes(typesToCheck)){
-            types.push(typesToCheck);
-          }
+    if(typesToCheck !== undefined){
+      if(types === undefined){
+        types = typesToCheck;
+      } else {
+        if(Array.isArray(typesToCheck)){
+          typesToCheck.forEach(addToTypes);
         }else{
-          if(types !== typesToCheck){
-            types = [types, typesToCheck]
+          if(Array.isArray(types)){
+            if(!types.includes(typesToCheck)){
+              types.push(typesToCheck);
+            }
+          }else{
+            if(types !== typesToCheck){
+              types = [types, typesToCheck]
+            }
           }
         }
       }
@@ -69,11 +70,7 @@ export default function simplifyTypes(schema: Schema | boolean) : string[] | str
       }
       const typeOfEnum = typeof value;
       switch(typeOfEnum){
-        //This should never happen, but just to be sure
-        case "undefined": 
-        case "function":
-        case "symbol":
-          return;
+        //We don't need to check undefined, function, symbol since it should never be possible
         case "bigint": 
           return "number";
         default:
@@ -102,8 +99,7 @@ export default function simplifyTypes(schema: Schema | boolean) : string[] | str
     let notTypes = simplifyTypes(schema.not);
     let remainingTypes = ["object", "string", "number", "array", "boolean", "null"];
     const tryAndCutRemainingArray = (notType : string | undefined) => {
-      if(notType === undefined) return;
-      if(remainingTypes.includes(notType)){
+      if(notType !== undefined && remainingTypes.includes(notType)){
         remainingTypes.splice(remainingTypes.indexOf(notType), 1);
       }
     }

--- a/test/simplification/types.spec.ts
+++ b/test/simplification/types.spec.ts
@@ -153,6 +153,11 @@ describe('Simplification of types', function() {
       const types = simplifyTypes(schema);
       expect(types).toEqual("number");
     });
+    test('with bigint', function() {
+      const schema = {const: BigInt(123)};
+      const types = simplifyTypes(schema);
+      expect(types).toEqual("number");
+    });
     test('with array', function() {
       const schema = {
         const: ["test"]
@@ -170,12 +175,25 @@ describe('Simplification of types', function() {
     });
   });
   describe('from not', function() {
-    test('with all types', function() {
-      const schemaString = fs.readFileSync(path.resolve(__dirname, './types/not.json'), 'utf8');
-      const schema = JSON.parse(schemaString);
+    test('with only one type', function() {
+      const schema = {
+          "not": {
+              "type": "string"
+          }
+      };
       const types = simplifyTypes(schema);
       expect(Array.isArray(types)).toEqual(true);
       expect((types as String[]).sort()).toEqual(["object", "number", "array", "boolean", "null"].sort());
+    });
+    test('with multiple types', function() {
+      const schema = {
+          "not": {
+              "type": ["string", "number"]
+          }
+      };
+      const types = simplifyTypes(schema);
+      expect(Array.isArray(types)).toEqual(true);
+      expect((types as String[]).sort()).toEqual(["object", "array", "boolean", "null"].sort());
     });
   });
 });

--- a/test/simplification/types.spec.ts
+++ b/test/simplification/types.spec.ts
@@ -11,32 +11,32 @@ describe('Simplification of types', function() {
     test('should return number type', function() {
       const schema: any = { type: 'number' };
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["number"]);
+      expect(types).toEqual("number");
     });
     test('should return object type', function() {
       const schema: any = { type: 'object' };
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["object"]);
+      expect(types).toEqual("object");
     });
     test('should return array type', function() {
       const schema: any = { type: 'array' };
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["array"]);
+      expect(types).toEqual("array");
     });
     test('should return null type', function() {
       const schema: any = { type: 'null' };
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["null"]);
+      expect(types).toEqual("null");
     });
     test('should return boolean type', function() {
       const schema: any = { type: 'boolean' };
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["boolean"]);
+      expect(types).toEqual("boolean");
     });
     test('should return string type', function() {
       const schema: any = { type: 'string' };
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["string"]);
+      expect(types).toEqual("string");
     });
   });
   describe('absence of types', function() {
@@ -56,13 +56,15 @@ describe('Simplification of types', function() {
       const schemaString = fs.readFileSync(path.resolve(__dirname, './types/allOf.json'), 'utf8');
       const schema = JSON.parse(schemaString);
       const types = simplifyTypes(schema);
-      expect(types.sort()).toEqual(["string", "number"].sort());
+      expect(Array.isArray(types)).toEqual(true);
+      expect((types as String[]).sort()).toEqual(["string", "number"].sort());
     });
     test('with nested schema', function() {
       const schemaString = fs.readFileSync(path.resolve(__dirname, './types/allOfNested.json'), 'utf8');
       const schema = JSON.parse(schemaString);
       const types = simplifyTypes(schema);
-      expect(types.sort()).toEqual(["string", "number", "boolean"].sort());
+      expect(Array.isArray(types)).toEqual(true);
+      expect((types as String[]).sort()).toEqual(["string", "number", "boolean"].sort());
     });
   });
 
@@ -71,13 +73,15 @@ describe('Simplification of types', function() {
       const schemaString = fs.readFileSync(path.resolve(__dirname, './types/oneOf.json'), 'utf8');
       const schema = JSON.parse(schemaString);
       const types = simplifyTypes(schema);
-      expect(types.sort()).toEqual(["string", "number"].sort());
+      expect(Array.isArray(types)).toEqual(true);
+      expect((types as String[]).sort()).toEqual(["string", "number"].sort());
     });
     test('with nested schema', function() {
       const schemaString = fs.readFileSync(path.resolve(__dirname, './types/oneOfNested.json'), 'utf8');
       const schema = JSON.parse(schemaString);
       const types = simplifyTypes(schema);
-      expect(types.sort()).toEqual(["string", "number", "boolean"].sort());
+      expect(Array.isArray(types)).toEqual(true);
+      expect((types as String[]).sort()).toEqual(["string", "number", "boolean"].sort());
     });
   });
 
@@ -86,13 +90,15 @@ describe('Simplification of types', function() {
       const schemaString = fs.readFileSync(path.resolve(__dirname, './types/anyOf.json'), 'utf8');
       const schema = JSON.parse(schemaString);
       const types = simplifyTypes(schema);
-      expect(types.sort()).toEqual(["string", "number"].sort());
+      expect(Array.isArray(types)).toEqual(true);
+      expect((types as String[]).sort()).toEqual(["string", "number"].sort());
     });
     test('with nested schema', function() {
       const schemaString = fs.readFileSync(path.resolve(__dirname, './types/anyOfNested.json'), 'utf8');
       const schema = JSON.parse(schemaString);
       const types = simplifyTypes(schema);
-      expect(types.sort()).toEqual(["string", "number", "boolean"].sort());
+      expect(Array.isArray(types)).toEqual(true);
+      expect((types as String[]).sort()).toEqual(["string", "number", "boolean"].sort());
     });
   });
   describe('from conditional if/then/else ', function() {
@@ -100,13 +106,15 @@ describe('Simplification of types', function() {
       const schemaString = fs.readFileSync(path.resolve(__dirname, './types/conditional.json'), 'utf8');
       const schema = JSON.parse(schemaString);
       const types = simplifyTypes(schema);
-      expect(types.sort()).toEqual(["string", "number", "boolean"].sort());
+      expect(Array.isArray(types)).toEqual(true);
+      expect((types as String[]).sort()).toEqual(["string", "number", "boolean"].sort());
     });
     test('with nested schema', function() {
       const schemaString = fs.readFileSync(path.resolve(__dirname, './types/conditionalNested.json'), 'utf8');
       const schema = JSON.parse(schemaString);
       const types = simplifyTypes(schema);
-      expect(types.sort()).toEqual(["string", "number", "boolean", "null", "array"].sort());
+      expect(Array.isArray(types)).toEqual(true);
+      expect((types as String[]).sort()).toEqual(["string", "number", "boolean", "null", "array"].sort());
     });
   });
   describe('from enum', function() {
@@ -114,42 +122,43 @@ describe('Simplification of types', function() {
       const schemaString = fs.readFileSync(path.resolve(__dirname, './types/enumIgnoreInvalid.json'), 'utf8');
       const schema = JSON.parse(schemaString);
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["string"]);
+      expect(types).toEqual("string");
     });
     test('with all types', function() {
       const schemaString = fs.readFileSync(path.resolve(__dirname, './types/enum.json'), 'utf8');
       const schema = JSON.parse(schemaString);
       const types = simplifyTypes(schema);
-      expect(types.sort()).toEqual(["object", "string", "number", "array", "boolean", "null"].sort());
+      expect(Array.isArray(types)).toEqual(true);
+      expect((types as String[]).sort()).toEqual(["object", "string", "number", "array", "boolean", "null"].sort());
     });
   });
   describe('from const', function() {
     test('with string', function() {
       const schema = {const: "something"};
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["string"]);
+      expect(types).toEqual("string");
     });
     test('with boolean', function() {
       const schema = {const: true};
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["boolean"]);
+      expect(types).toEqual("boolean");
     });
     test('with null', function() {
       const schema = {const: null};
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["null"]);
+      expect(types).toEqual("null");
     });
     test('with number', function() {
       const schema = {const: 123};
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["number"]);
+      expect(types).toEqual("number");
     });
     test('with array', function() {
       const schema = {
         const: ["test"]
       };
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["array"]);
+      expect(types).toEqual("array");
     });
     test('Should not infer type if defined earlier', function() {
       const schema = {
@@ -157,7 +166,7 @@ describe('Simplification of types', function() {
         const: ["test"]
       };
       const types = simplifyTypes(schema);
-      expect(types).toEqual(["boolean"]);
+      expect(types).toEqual("boolean");
     });
   });
   describe('from not', function() {
@@ -165,7 +174,8 @@ describe('Simplification of types', function() {
       const schemaString = fs.readFileSync(path.resolve(__dirname, './types/not.json'), 'utf8');
       const schema = JSON.parse(schemaString);
       const types = simplifyTypes(schema);
-      expect(types.sort()).toEqual(["object", "number", "array", "boolean", "null"].sort());
+      expect(Array.isArray(types)).toEqual(true);
+      expect((types as String[]).sort()).toEqual(["object", "number", "array", "boolean", "null"].sort());
     });
   });
 });


### PR DESCRIPTION
**Description**
This PR ensures that types can be primitives by not resolving into an array all the time. This is to simplify the rendering phase.

