### PR TITLE
chore: fix $id is preserved in original schema when it should not

### DIFF
--- a/src/simplification/Simplify.ts
+++ b/src/simplification/Simplify.ts
@@ -18,8 +18,8 @@ export function simplifyRecursive(schema : Schema | boolean) : CommonModel[] {
     //Get the root model from the simplification process which is the last element in the list
     //This is because any intermediary models are put in front of the root
     const rootSimplifiedModel = simplifiedModel[simplifiedModel.length-1];
-    //Only if it contains object and is the only type
-    if(rootSimplifiedModel.type !== undefined && typeof schema !== "boolean" && rootSimplifiedModel.type.includes("object") && rootSimplifiedModel.properties !== undefined){
+    //Only if the schema is of type object and contains properties, split it out
+    if(rootSimplifiedModel.type !== undefined && rootSimplifiedModel.type.includes("object") && rootSimplifiedModel.properties !== undefined){
       let switchRootModel = new CommonModel();
       switchRootModel.$ref = rootSimplifiedModel.$id;
       models[0] = switchRootModel;

--- a/src/simplification/Simplify.ts
+++ b/src/simplification/Simplify.ts
@@ -14,12 +14,16 @@ let anonymCounter = 1;
 export function simplifyRecursive(schema : Schema | boolean) : CommonModel[] {
   let models : CommonModel[] = [];
   let simplifiedModel = simplify(schema);
-  const rootSimplifiedModel = simplifiedModel[0];
-  //Only if it contains object and is the only type
-  if(rootSimplifiedModel.type !== undefined && typeof schema !== "boolean" && rootSimplifiedModel.type.includes("object") && rootSimplifiedModel.properties !== undefined){
-    let switchRootModel = new CommonModel();
-    switchRootModel.$ref = rootSimplifiedModel.$id;
-    models[0] = switchRootModel;
+  if(simplifiedModel.length > 0){
+    //Get the root model from the simplification process which is the last element in the list
+    //This is because any intermediary models are put in front of the root
+    const rootSimplifiedModel = simplifiedModel[simplifiedModel.length-1];
+    //Only if it contains object and is the only type
+    if(rootSimplifiedModel.type !== undefined && typeof schema !== "boolean" && rootSimplifiedModel.type.includes("object") && rootSimplifiedModel.properties !== undefined){
+      let switchRootModel = new CommonModel();
+      switchRootModel.$ref = rootSimplifiedModel.$id;
+      models[0] = switchRootModel;
+    }
   }
   models = [...models, ...simplifiedModel];
   return models;

--- a/src/simplification/Simplify.ts
+++ b/src/simplification/Simplify.ts
@@ -13,13 +13,13 @@ let anonymCounter = 1;
  */
 export function simplifyRecursive(schema : Schema | boolean) : CommonModel[] {
   let models : CommonModel[] = [];
-  let types = simplifyTypes(schema);
   let simplifiedModel = simplify(schema);
+  const rootSimplifiedModel = simplifiedModel[0];
   //Only if it contains object and is the only type
-  if(types !== undefined && typeof schema !== "boolean" && types.includes("object") && simplifiedModel[0].properties !== undefined){
-    let rootModel = new CommonModel();
-    rootModel.$ref = schema.$id;
-    models[0] = rootModel;
+  if(rootSimplifiedModel.type !== undefined && typeof schema !== "boolean" && rootSimplifiedModel.type.includes("object") && rootSimplifiedModel.properties !== undefined){
+    let switchRootModel = new CommonModel();
+    switchRootModel.$ref = rootSimplifiedModel.$id;
+    models[0] = switchRootModel;
   }
   models = [...models, ...simplifiedModel];
   return models;
@@ -43,7 +43,6 @@ export function simplify(schema : Schema | boolean) : CommonModel[] {
     //All schemas of type object MUST have ids, for now lets make it simple
     if(model.type !== undefined && model.type.includes("object")){
       let schemaId = schema.$id ? schema.$id : `anonymSchema${anonymCounter++}`;
-      schema.$id = schemaId;
       model.$id = schemaId;
     } else if (schema.$id !== undefined){
       model.$id = schema.$id;

--- a/test/simplification/simplify.spec.ts
+++ b/test/simplification/simplify.spec.ts
@@ -1,0 +1,20 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {simplify} from '../../src/simplification/Simplify';
+
+/**
+ * Some of these test are purely theoretical and have little if any merit 
+ * on a JSON Schema which actually makes sense but are used to test the principles.
+ */
+describe('Simplification', function() {
+  test('should return as is', function() {
+    const inputSchemaString = fs.readFileSync(path.resolve(__dirname, './simplify/multipleObjects.json'), 'utf8');
+    const expectedSchemaString = fs.readFileSync(path.resolve(__dirname, './simplify/expected/multipleObjects.json'), 'utf8');
+    const schema = JSON.parse(inputSchemaString);
+    const expectedModels = JSON.parse(expectedSchemaString);
+    const actualModels = simplify(schema);
+    expect(actualModels).not.toBeUndefined();
+    expect(actualModels[0]).toEqual(expectedModels[1]);
+    expect(actualModels[1]).toEqual(expectedModels[0]);
+  });
+});

--- a/test/simplification/simplify.spec.ts
+++ b/test/simplification/simplify.spec.ts
@@ -16,5 +16,6 @@ describe('Simplification', function() {
     expect(actualModels).not.toBeUndefined();
     expect(actualModels[0]).toEqual(expectedModels[1]);
     expect(actualModels[1]).toEqual(expectedModels[0]);
+    expect(schema.$id).toBeUndefined();
   });
 });

--- a/test/simplification/simplify/expected/multipleObjects.json
+++ b/test/simplification/simplify/expected/multipleObjects.json
@@ -1,0 +1,54 @@
+[
+  {
+    "type": "object",
+    "$id": "anonymSchema1",
+    "properties": {
+      "street_address": {
+        "$ref": "anonymSchema2"
+      },
+      "country": {
+        "type": "string",
+        "enum": ["United States of America", "Canada"],
+        "originalSchema": {
+          "enum": ["United States of America", "Canada"]
+        }
+      }
+    },
+    "originalSchema": {
+      "type": "object",
+      "properties": {
+        "street_address": {
+          "type": "object",
+          "properties": {
+            "floor": {
+              "type": "number"
+            }
+          }
+        },
+        "country": {
+          "enum": ["United States of America", "Canada"]
+        }
+      }
+    }
+  },
+  {
+    "$id": "anonymSchema2",
+    "type": "object",
+    "properties": {
+      "floor": {
+        "type": "number",
+        "originalSchema": {
+          "type": "number"
+        }
+      }
+    },
+    "originalSchema": {
+      "type": "object",
+      "properties": {
+        "floor": {
+          "type": "number"
+        }
+      }
+    }
+  }
+]

--- a/test/simplification/simplify/multipleObjects.json
+++ b/test/simplification/simplify/multipleObjects.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "street_address": {
+      "type": "object",
+      "properties": {
+        "floor": {
+          "type": "number"
+        }
+      }
+    },
+    "country": {
+      "enum": ["United States of America", "Canada"]
+    }
+  }
+}


### PR DESCRIPTION
**Description**
This PR fixes that `$id` is preserved in original schema.