### PR TITLE
chore: moved tests around

### DIFF
--- a/test/simplification/items.spec.ts
+++ b/test/simplification/items.spec.ts
@@ -111,72 +111,13 @@ describe('Simplification of items', function () {
     });
   });
   test('Should split out multiple objects into their own models and add reference', function () {
-    const schemaString = fs.readFileSync(path.resolve(__dirname, './items/multipleObjects.json'), 'utf8');
-    const schema = JSON.parse(schemaString);
+    const inputSchemaString = fs.readFileSync(path.resolve(__dirname, './items/multipleObjects.json'), 'utf8');
+    const expectedCommonInputModelString = fs.readFileSync(path.resolve(__dirname, './items/expected/multipleObjects.json'), 'utf8');
+    const inputSchema = JSON.parse(inputSchemaString);
+    const expectedCommonInputModel = JSON.parse(expectedCommonInputModelString);
     const simplifier = new Simplifier();
-    const output = simplifyItems(schema, simplifier);
-    expect(output.newModels).toHaveLength(2);
-    expect(output.newModels![0]).toEqual({
-      originalSchema: {
-        type: "object",
-        properties: {
-          floor: {
-            type: "number",
-          },
-        },
-      },
-      type: "object",
-      $id: "anonymSchema2",
-      properties: {
-        floor: {
-          originalSchema: {
-            type: "number",
-          },
-          type: "number",
-        },
-      },
-    });
-    expect(output.newModels![1]).toEqual({
-      originalSchema: {
-        type: "object",
-        properties: {
-          street_address: {
-            type: "object",
-            properties: {
-              floor: {
-                type: "number",
-              },
-            },
-          },
-          country: {
-            enum: [
-              "United States of America",
-              "Canada",
-            ],
-          },
-        },
-      },
-      type: "object",
-      $id: "anonymSchema1",
-      properties: {
-        street_address: {
-          $ref: "anonymSchema2",
-        },
-        country: {
-          originalSchema: {
-            enum: [
-              "United States of America",
-              "Canada",
-            ],
-          },
-          type: "string",
-          enum: [
-            "United States of America",
-            "Canada",
-          ],
-        },
-      },
-    });
+    const output = simplifyItems(inputSchema, simplifier);
+    expect(output.newModels).toEqual(expectedCommonInputModel);
     expect(output.items).toEqual({
       $ref: "anonymSchema1"
     });

--- a/test/simplification/items/expected/multipleObjects.json
+++ b/test/simplification/items/expected/multipleObjects.json
@@ -1,0 +1,63 @@
+[
+  {
+    "originalSchema": {
+      "type": "object",
+      "properties": {
+        "floor": {
+          "type": "number"
+        }
+      }
+    },
+    "type": "object",
+    "$id": "anonymSchema2",
+    "properties": {
+      "floor": {
+        "originalSchema": {
+          "type": "number"
+        },
+        "type": "number"
+      }
+    }
+  },
+  {
+    "originalSchema": {
+      "type": "object",
+      "properties": {
+        "street_address": {
+          "type": "object",
+          "properties": {
+            "floor": {
+              "type": "number"
+            }
+          }
+        },
+        "country": {
+          "enum": [
+            "United States of America",
+            "Canada"
+          ]
+        }
+      }
+    },
+    "type": "object",
+    "$id": "anonymSchema1",
+    "properties": {
+      "street_address": {
+        "$ref": "anonymSchema2"
+      },
+      "country": {
+        "originalSchema": {
+          "enum": [
+            "United States of America",
+            "Canada"
+          ]
+        },
+        "type": "string",
+        "enum": [
+          "United States of America",
+          "Canada"
+        ]
+      }
+    }
+  }
+]

--- a/test/simplification/properties.spec.ts
+++ b/test/simplification/properties.spec.ts
@@ -4,335 +4,92 @@ import Simplifier from '../../src/simplification/Simplifier';
 import simplifyProperties from '../../src/simplification/SimplifyProperties';
 
 /**
+ * 
+ * @param inputSchemaPath 
+ * @param expectedPropertiesPath 
+ */
+const expectFunction = (inputSchemaPath: string, expectedPropertiesPath: string) => {
+  const inputSchemaString = fs.readFileSync(path.resolve(__dirname, inputSchemaPath), 'utf8');
+  const expectedCommonInputModelString = fs.readFileSync(path.resolve(__dirname, expectedPropertiesPath), 'utf8');
+  const inputSchema = JSON.parse(inputSchemaString);
+  const expectedProperties = JSON.parse(expectedCommonInputModelString);
+  const simplifier = new Simplifier();
+  const { newModels, properties } = simplifyProperties(inputSchema, simplifier);
+  expect(newModels).toBeUndefined();
+  expect(properties).toEqual(expectedProperties);
+}
+/**
  * Some of these test are purely theoretical and have little if any merit 
  * on a JSON Schema which actually makes sense but are used to test the principles.
  */
 describe('Simplification of properties', function () {
   test('should return as is', function () {
-    const schemaString = fs.readFileSync(path.resolve(__dirname, './properties/basic.json'), 'utf8');
-    const schema = JSON.parse(schemaString);
-    const simplifier = new Simplifier();
-    const { newModels, properties } = simplifyProperties(schema, simplifier);
-    expect(newModels).toBeUndefined();
-    expect(properties).toEqual({
-      "testProp1": {
-        "type": "string",
-        "originalSchema": {
-          "type": "string"
-        }
-      },
-      "testProp2": {
-        "type": "string",
-        "originalSchema": {
-          "type": "string"
-        }
-      }
-    });
+    const inputSchemaPath = './properties/basic.json';
+    const expectedPropertiesPath = './properties/expected/basic.json';
+    expectFunction(inputSchemaPath, expectedPropertiesPath);
   });
   describe('from allOf schemas', function () {
     test('with simple schema', function () {
-      const schemaString = fs.readFileSync(path.resolve(__dirname, './properties/allOf.json'), 'utf8');
-      const schema = JSON.parse(schemaString);
-      const simplifier = new Simplifier();
-      const { newModels, properties } = simplifyProperties(schema, simplifier);
-      expect(newModels).toBeUndefined();
-      expect(properties).toEqual({
-        "testProp1": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp2": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        }
-      });
+      const inputSchemaPath = './properties/allOf.json';
+      const expectedPropertiesPath = './properties/expected/allOf.json';
+      expectFunction(inputSchemaPath, expectedPropertiesPath);
     });
     test('with nested schema', function () {
-      const schemaString = fs.readFileSync(path.resolve(__dirname, './properties/allOfNested.json'), 'utf8');
-      const schema = JSON.parse(schemaString);
-      const simplifier = new Simplifier();
-      const { newModels, properties } = simplifyProperties(schema, simplifier);
-      expect(newModels).toBeUndefined();
-      expect(properties).toEqual({
-        "testProp1": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp2": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp3": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        }
-      });
+      const inputSchemaPath = './properties/allOfNested.json';
+      const expectedPropertiesPath = './properties/expected/allOfNested.json';
+      expectFunction(inputSchemaPath, expectedPropertiesPath);
     });
   });
   describe('from anyOf schemas', function () {
     test('with simple schema', function () {
-      const schemaString = fs.readFileSync(path.resolve(__dirname, './properties/anyOf.json'), 'utf8');
-      const schema = JSON.parse(schemaString);
-      const simplifier = new Simplifier();
-      const { newModels, properties } = simplifyProperties(schema, simplifier);
-      expect(newModels).toBeUndefined();
-      expect(properties).toEqual({
-        "testProp1": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp2": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        }
-      });
+      const inputSchemaPath = './properties/anyOf.json';
+      const expectedPropertiesPath = './properties/expected/anyOf.json';
+      expectFunction(inputSchemaPath, expectedPropertiesPath);
     });
     test('with nested schema', function () {
-      const schemaString = fs.readFileSync(path.resolve(__dirname, './properties/anyOfNested.json'), 'utf8');
-      const schema = JSON.parse(schemaString);
-      const simplifier = new Simplifier();
-      const { newModels, properties } = simplifyProperties(schema, simplifier);
-      expect(newModels).toBeUndefined();
-      expect(properties).toEqual({
-        "testProp1": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp2": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp3": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        }
-      });
+      const inputSchemaPath = './properties/anyOfNested.json';
+      const expectedPropertiesPath = './properties/expected/anyOfNested.json';
+      expectFunction(inputSchemaPath, expectedPropertiesPath);
     });
   });
   describe('from oneOf schemas', function () {
     test('with simple schema', function () {
-      const schemaString = fs.readFileSync(path.resolve(__dirname, './properties/oneOf.json'), 'utf8');
-      const schema = JSON.parse(schemaString);
-      const simplifier = new Simplifier();
-      const { newModels, properties } = simplifyProperties(schema, simplifier);
-      expect(newModels).toBeUndefined();
-      expect(properties).toEqual({
-        "testProp1": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp2": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        }
-      });
+      const inputSchemaPath = './properties/oneOf.json';
+      const expectedPropertiesPath = './properties/expected/oneOf.json';
+      expectFunction(inputSchemaPath, expectedPropertiesPath);
     });
     test('with nested oneOf schemas', function () {
-      const schemaString = fs.readFileSync(path.resolve(__dirname, './properties/oneOfNested.json'), 'utf8');
-      const schema = JSON.parse(schemaString);
-      const simplifier = new Simplifier();
-      const { newModels, properties } = simplifyProperties(schema, simplifier);
-      expect(newModels).toBeUndefined();
-      expect(properties).toEqual({
-        "testProp1": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp2": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp3": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        }
-      });
+      const inputSchemaPath = './properties/oneOfNested.json';
+      const expectedPropertiesPath = './properties/expected/oneOfNested.json';
+      expectFunction(inputSchemaPath, expectedPropertiesPath);
     });
   });
   describe('from if/then/else schemas', function () {
     test('with simple schema', function () {
-      const schemaString = fs.readFileSync(path.resolve(__dirname, './properties/conditional.json'), 'utf8');
-      const schema = JSON.parse(schemaString);
-      const simplifier = new Simplifier();
-      const { newModels, properties } = simplifyProperties(schema, simplifier);
-      expect(newModels).toBeUndefined();
-      expect(properties).toEqual({
-        "testProp1": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp2": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp3": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        }
-      });
+      const inputSchemaPath = './properties/conditional.json';
+      const expectedPropertiesPath = './properties/expected/conditional.json';
+      expectFunction(inputSchemaPath, expectedPropertiesPath);
     });
     test('with nested schema', function () {
-      const schemaString = fs.readFileSync(path.resolve(__dirname, './properties/conditionalNested.json'), 'utf8');
-      const schema = JSON.parse(schemaString);
-      const simplifier = new Simplifier();
-      const { newModels, properties } = simplifyProperties(schema, simplifier);
-      expect(newModels).toBeUndefined();
-      expect(properties).toEqual({
-        "testProp1": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp2": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp3": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp4": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        },
-        "testProp5": {
-          "type": "string",
-          "originalSchema": {
-            "type": "string"
-          }
-        }
-      });
+      const inputSchemaPath = './properties/conditionalNested.json';
+      const expectedPropertiesPath = './properties/expected/conditionalNested.json';
+      expectFunction(inputSchemaPath, expectedPropertiesPath);
     });
   });
   test('Should merge properties which same key', function () {
-    const schemaString = fs.readFileSync(path.resolve(__dirname, './properties/combine_properties.json'), 'utf8');
-    const schema = JSON.parse(schemaString);
-    const simplifier = new Simplifier();
-    const { newModels, properties } = simplifyProperties(schema, simplifier);
-    expect(newModels).toBeUndefined();
-    expect(properties).toEqual(expect.objectContaining({
-      "testProp1": {
-        originalSchema: {
-          allOf: [
-            {
-              properties: {
-                testProp1: {
-                  type: "string",
-                  enum: [
-                    "merge",
-                  ],
-                },
-              },
-            },
-            {
-              properties: {
-                testProp1: {
-                  type: "number",
-                  enum: [
-                    0,
-                  ],
-                },
-              },
-            },
-          ],
-        },
-        type: [
-          "string",
-          "number",
-        ],
-        enum: [
-          "merge",
-          0,
-        ],
-      }
-    }));
+    const inputSchemaPath = './properties/combine_properties.json';
+    const expectedPropertiesPath = './properties/expected/combine_properties.json';
+    expectFunction(inputSchemaPath, expectedPropertiesPath);
   });
   test('Should split out multiple objects into their own models and add reference', function () {
-    const schemaString = fs.readFileSync(path.resolve(__dirname, './properties/multiple_objects.json'), 'utf8');
-    const schema = JSON.parse(schemaString);
+    const inputSchemaString = fs.readFileSync(path.resolve(__dirname, './properties/multiple_objects.json'), 'utf8');
+    const expectedCommonInputModelString = fs.readFileSync(path.resolve(__dirname, './properties/expected/multiple_objects.json'), 'utf8');
+    const inputSchema = JSON.parse(inputSchemaString);
+    const expectedProperties = JSON.parse(expectedCommonInputModelString);
     const simplifier = new Simplifier();
-    const { newModels, properties } = simplifyProperties(schema, simplifier);
+    const { newModels, properties } = simplifyProperties(inputSchema, simplifier);
     expect(newModels).toHaveLength(1);
-    expect(newModels).toEqual(expect.arrayContaining([expect.objectContaining({
-      originalSchema: {
-        type: "object",
-        properties: {
-          floor: {
-            type: "number",
-          },
-        },
-      },
-      type: "object",
-      $id: "anonymSchema1",
-      properties: {
-        floor: {
-          originalSchema: {
-            type: "number",
-          },
-          type: "number",
-        },
-      },
-    })]));
-    expect(properties).toMatchObject({
-      street_address: {
-        $ref: "anonymSchema1",
-      },
-      country: {
-        originalSchema: {
-          enum: [
-            "United States of America",
-            "Canada",
-          ],
-        },
-        type: "string",
-        enum: [
-          "United States of America",
-          "Canada",
-        ],
-      },
-    });
+    expect(newModels).toEqual(expectedProperties.newModels);
+    expect(properties).toEqual(expectedProperties.properties);
   });
 });

--- a/test/simplification/properties/expected/allOf.json
+++ b/test/simplification/properties/expected/allOf.json
@@ -1,0 +1,14 @@
+{
+  "testProp1":{
+    "originalSchema":{
+      "type":"string"
+    },
+    "type":"string"
+  },
+  "testProp2":{
+    "originalSchema":{
+      "type":"string"
+    },
+    "type":"string"
+  }
+}

--- a/test/simplification/properties/expected/allOfNested.json
+++ b/test/simplification/properties/expected/allOfNested.json
@@ -1,0 +1,20 @@
+{
+  "testProp1": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp2": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp3": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  }
+}

--- a/test/simplification/properties/expected/anyOf.json
+++ b/test/simplification/properties/expected/anyOf.json
@@ -1,0 +1,14 @@
+{
+  "testProp1": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp2": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  }
+}

--- a/test/simplification/properties/expected/anyOfNested.json
+++ b/test/simplification/properties/expected/anyOfNested.json
@@ -1,0 +1,20 @@
+{
+  "testProp1": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp2": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp3": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  }
+}

--- a/test/simplification/properties/expected/basic.json
+++ b/test/simplification/properties/expected/basic.json
@@ -1,0 +1,14 @@
+{
+  "testProp1": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp2": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  }
+}

--- a/test/simplification/properties/expected/combine_properties.json
+++ b/test/simplification/properties/expected/combine_properties.json
@@ -1,0 +1,36 @@
+{
+  "testProp1":{
+    "originalSchema":{
+      "allOf":[
+        {
+          "properties":{
+            "testProp1":{
+              "type":"string",
+              "enum":[
+                "merge"
+              ]
+            }
+          }
+        },
+        {
+          "properties":{
+            "testProp1":{
+              "type":"number",
+              "enum":[
+                0
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "type":[
+      "string",
+      "number"
+    ],
+    "enum":[
+      "merge",
+      0
+    ]
+  }
+}

--- a/test/simplification/properties/expected/conditional.json
+++ b/test/simplification/properties/expected/conditional.json
@@ -1,0 +1,20 @@
+{
+  "testProp1": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp2": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp3": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  }
+}

--- a/test/simplification/properties/expected/conditionalNested.json
+++ b/test/simplification/properties/expected/conditionalNested.json
@@ -1,0 +1,32 @@
+{
+  "testProp1": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp2": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp3": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp4": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp5": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  }
+}

--- a/test/simplification/properties/expected/multiple_objects.json
+++ b/test/simplification/properties/expected/multiple_objects.json
@@ -1,0 +1,42 @@
+{
+  "newModels": [
+    {
+      "originalSchema": {
+        "type": "object",
+        "properties": {
+          "floor": {
+            "type": "number"
+          }
+        }
+      },
+      "type": "object",
+      "$id": "anonymSchema1",
+      "properties": {
+        "floor": {
+          "originalSchema": {
+            "type": "number"
+          },
+          "type": "number"
+        }
+      }
+    }
+  ],
+  "properties": {
+    "street_address":{
+      "$ref":"anonymSchema1"
+    },
+    "country":{
+      "originalSchema":{
+        "enum":[
+          "United States of America",
+          "Canada"
+        ]
+      },
+      "type":"string",
+      "enum":[
+        "United States of America",
+        "Canada"
+      ]
+    }
+  }
+}

--- a/test/simplification/properties/expected/oneOf.json
+++ b/test/simplification/properties/expected/oneOf.json
@@ -1,0 +1,14 @@
+{
+  "testProp1": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp2": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  }
+}

--- a/test/simplification/properties/expected/oneOfNested.json
+++ b/test/simplification/properties/expected/oneOfNested.json
@@ -1,0 +1,20 @@
+{
+  "testProp1": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp2": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  },
+  "testProp3": {
+    "type": "string",
+    "originalSchema": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
**Description**
This PR moves test cases into separated files for simplicity. I simply moved all inline objects into separate expected test outcomes.