### PR TITLE
chore: removes eslint warnings from property simplification

### DIFF
--- a/src/simplification/SimplifyProperties.ts
+++ b/src/simplification/SimplifyProperties.ts
@@ -16,56 +16,71 @@ export default function simplifyProperties(schema: Schema | boolean, simplifier 
     if (seenSchemas.has(schema)) return seenSchemas.get(schema);
     const output: Output = {};
     seenSchemas.set(schema, output);
-    const addToProperty = (propName: string, propModel: CommonModel) => {
-      if (output !== undefined) {
-        //If a simplified property already exist, merge the two
-        if (output[`${propName}`] !== undefined) {
-          output[`${propName}`] = CommonModel.mergeCommonModels(output[`${propName}`], propModel, schema);
-        } else {
-          output[`${propName}`] = propModel;
-        }
-      }
-    };
-    const addProperties = (out: Output) => {
-      if (out !== undefined) {
-        for (const [prop, propSchema] of Object.entries(out)) {
-          addToProperty(prop, propSchema);
-        }
-      }
-    };
-    const handleCombinationSchemas = (combinationSchemas: (Schema | boolean)[] = []) => {
-      combinationSchemas.forEach((combinationSchema) => {
-        addProperties(simplifyProperties(combinationSchema, simplifier, seenSchemas));
-      });
-    };
-
-    if (schema.properties !== undefined) {
-      for (const [prop, propSchema] of Object.entries(schema.properties)) {
-        const newModels = simplifier.simplify(propSchema);
-        if (newModels.length > 0) {
-          addToProperty(prop, newModels[0]);
-        }
+  
+    for (const [prop, propSchema] of Object.entries(schema.properties || {})) {
+      const newModels = simplifier.simplify(propSchema);
+      if (newModels.length > 0) {
+        addToProperty(prop, newModels[0], schema, output);
       }
     }
+
     //If we encounter combination schemas ensure we recursively find the properties
     if (simplifier.options.allowInheritance !== true) {
       //Only merge allOf schemas if we don't allow inheritance
-      handleCombinationSchemas(schema.allOf);
+      combineSchemas(schema.allOf, output, simplifier, seenSchemas, schema);
     }
-    handleCombinationSchemas(schema.oneOf);
-    handleCombinationSchemas(schema.anyOf);
+    combineSchemas(schema.oneOf, output, simplifier, seenSchemas, schema);
+    combineSchemas(schema.anyOf, output, simplifier, seenSchemas, schema);
 
     //If we encounter combination schemas ensure we recursively find the properties
-    if (schema.then) {
-      addProperties(simplifyProperties(schema.then, simplifier, seenSchemas));
-    }
-    if (schema.else) {
-      addProperties(simplifyProperties(schema.else, simplifier, seenSchemas));
-    }
-    if (Object.keys(output).length === 0) {
-      return undefined;
-    }
-    return output;
+    combineSchemas(schema.then, output, simplifier, seenSchemas, schema);
+    combineSchemas(schema.else, output, simplifier, seenSchemas, schema);
+
+    return !Object.keys(output).length ? undefined : output;
   }
   return undefined;
+}
+
+/**
+ * Adds a property to the model
+ * 
+ * @param propName name of the property
+ * @param propModel the corresponding model
+ * @param schema the schema for the model
+ * @param currentModel the current output
+ */
+function addToProperty(propName: string, propModel: CommonModel, schema: Schema, currentModel: Output) {
+  if (currentModel === undefined) return;
+  //If a simplified property already exist, merge the two
+  if (currentModel[`${propName}`] !== undefined) {
+    currentModel[`${propName}`] = CommonModel.mergeCommonModels(currentModel[`${propName}`], propModel, schema);
+  } else {
+    currentModel[`${propName}`] = propModel;
+  }
+}
+
+/**
+ * Go through schema(s) and combine the simplified properties together.
+ * 
+ * @param schema to go through
+ * @param currentModel the current output
+ * @param simplifier the simplifier to use
+ * @param seenSchemas schemas which we already have outputs for
+ * @param rootSchema the root schema we are combining schemas for
+ */
+function combineSchemas(schema: (Schema | boolean) | (Schema | boolean)[] | undefined, currentModel: Output, simplifier : Simplifier, seenSchemas: Map<any, Output>, rootSchema : Schema) {
+  if (schema === undefined) return;
+  if (typeof schema === 'boolean') return;
+  if (Array.isArray(schema)) {
+    schema.forEach((combinationSchema) => {
+      combineSchemas(combinationSchema, currentModel, simplifier, seenSchemas, rootSchema);
+    });
+  } else {
+    const props = simplifyProperties(schema, simplifier, seenSchemas);
+    if (props !== undefined) {
+      for (const [prop, propSchema] of Object.entries(props)) {
+        addToProperty(prop, propSchema, rootSchema, currentModel);
+      }
+    }
+  }
 }

--- a/src/simplification/SimplifyProperties.ts
+++ b/src/simplification/SimplifyProperties.ts
@@ -69,8 +69,7 @@ function addToProperty(propName: string, propModel: CommonModel, schema: Schema,
  * @param rootSchema the root schema we are combining schemas for
  */
 function combineSchemas(schema: (Schema | boolean) | (Schema | boolean)[] | undefined, currentModel: Output, simplifier : Simplifier, seenSchemas: Map<any, Output>, rootSchema : Schema) {
-  if (schema === undefined) return;
-  if (typeof schema === 'boolean') return;
+  if (typeof schema !== 'object') return;
   if (Array.isArray(schema)) {
     schema.forEach((combinationSchema) => {
       combineSchemas(combinationSchema, currentModel, simplifier, seenSchemas, rootSchema);


### PR DESCRIPTION
**Description**
This PR removes all eslint warnings.

```
/home/runner/work/generator-model-sdk/generator-model-sdk/src/simplification/SimplifyProperties.ts
Warning:   14:25  warning  Refactor this function to reduce its Cognitive Complexity from 35 to the 15 allowed  sonarjs/cognitive-complexity
```
**Related issue(s)**
related to #53