### PR TITLE
fix: update JavaRenderer and remove unnecessary code from presets

### DIFF
--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -17,7 +17,8 @@ export class ClassRenderer extends JavaRenderer {
       await this.runAdditionalContentPreset(),
     ];
 
-    return `public class ${this.model.$id} {
+    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    return `public class ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}
 }`;
   }
@@ -31,15 +32,15 @@ ${this.indent(this.renderBlock(content, 2))}
     const content: string[] = [];
 
     for (const [propertyName, property] of Object.entries(properties)) {
-      const rendererProperty = await this.runPropertyPreset(propertyName, property, this.model);
+      const rendererProperty = await this.runPropertyPreset(propertyName, property);
       content.push(rendererProperty);
     }
 
     return this.renderBlock(content);
   }
 
-  async runPropertyPreset(propertyName: string, property: CommonModel, parentModel: CommonModel): Promise<string> {
-    return this.runPreset('property', { propertyName, property, parentModel });
+  async runPropertyPreset(propertyName: string, property: CommonModel): Promise<string> {
+    return this.runPreset('property', { propertyName, property });
   }
 
   async renderAccessors(): Promise<string> {
@@ -47,20 +48,20 @@ ${this.indent(this.renderBlock(content, 2))}
     const content: string[] = [];
 
     for (const [propertyName, property] of Object.entries(properties)) {
-      const getter = await this.runGetterPreset(propertyName, property, this.model);
-      const setter = await this.runSetterPreset(propertyName, property, this.model);
+      const getter = await this.runGetterPreset(propertyName, property);
+      const setter = await this.runSetterPreset(propertyName, property);
       content.push(this.renderBlock([getter, setter]));
     }
 
     return this.renderBlock(content, 2);
   }
 
-  async runGetterPreset(propertyName: string, property: CommonModel, parentModel: CommonModel): Promise<string> {
-    return this.runPreset('getter', { propertyName, property, parentModel });
+  async runGetterPreset(propertyName: string, property: CommonModel): Promise<string> {
+    return this.runPreset('getter', { propertyName, property });
   }
 
-  async runSetterPreset(propertyName: string, property: CommonModel, parentModel: CommonModel): Promise<string> {
-    return this.runPreset('setter', { propertyName, property, parentModel });
+  async runSetterPreset(propertyName: string, property: CommonModel): Promise<string> {
+    return this.runPreset('setter', { propertyName, property });
   }
 }
 

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -1,6 +1,6 @@
 import { JavaRenderer } from '../JavaRenderer';
 
-import { CommonModel, EnumPreset } from '../../../models';
+import { EnumPreset } from '../../../models';
 import { FormatHelpers } from '../../../helpers';
 
 /**
@@ -15,7 +15,8 @@ export class EnumRenderer extends JavaRenderer {
       await this.runAdditionalContentPreset(),
     ];
 
-    return `public enum ${this.model.$id} {
+    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    return `public enum ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}
 }`;
   }
@@ -25,7 +26,7 @@ ${this.indent(this.renderBlock(content, 2))}
     const items: string[] = [];
 
     for (const value of enums) {
-      const renderedItem = await this.runItemPreset(value, this.model);
+      const renderedItem = await this.runItemPreset(value);
       items.push(renderedItem);
     }
 
@@ -55,8 +56,8 @@ ${this.indent(this.renderBlock(content, 2))}
     }
   }
 
-  async runItemPreset(item: any, parentModel: CommonModel): Promise<string> {
-    return this.runPreset('item', { item, parentModel });
+  async runItemPreset(item: any): Promise<string> {
+    return this.runPreset('item', { item });
   }
 }
 

--- a/src/generators/javascript/renderers/ClassRenderer.ts
+++ b/src/generators/javascript/renderers/ClassRenderer.ts
@@ -17,7 +17,8 @@ export class ClassRenderer extends JavaScriptRenderer {
       await this.runAdditionalContentPreset(),
     ];
 
-    return `class ${this.model.$id} {
+    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    return `class ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}
 }`;
   }
@@ -31,20 +32,20 @@ ${this.indent(this.renderBlock(content, 2))}
     const content: string[] = [];
 
     for (const [propertyName, property] of Object.entries(properties)) {
-      const getter = await this.runGetterPreset(propertyName, property, this.model);
-      const setter = await this.runSetterPreset(propertyName, property, this.model);
+      const getter = await this.runGetterPreset(propertyName, property);
+      const setter = await this.runSetterPreset(propertyName, property);
       content.push(this.renderBlock([getter, setter]));
     }
 
     return this.renderBlock(content, 2);
   }
 
-  async runGetterPreset(propertyName: string, property: CommonModel, parentModel: CommonModel): Promise<string> {
-    return this.runPreset('getter', { propertyName, property, parentModel });
+  async runGetterPreset(propertyName: string, property: CommonModel): Promise<string> {
+    return this.runPreset('getter', { propertyName, property });
   }
 
-  async runSetterPreset(propertyName: string, property: CommonModel, parentModel: CommonModel): Promise<string> {
-    return this.runPreset('setter', { propertyName, property, parentModel });
+  async runSetterPreset(propertyName: string, property: CommonModel): Promise<string> {
+    return this.runPreset('setter', { propertyName, property });
   }
 }
 

--- a/src/generators/typescript/TypeScriptRenderer.ts
+++ b/src/generators/typescript/TypeScriptRenderer.ts
@@ -36,7 +36,7 @@ export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOpti
     if (type === undefined) {
       return 'any';
     }
-    switch (type) {
+    switch (type) { 
     case 'string':
       return 'string';
     case 'integer':
@@ -54,12 +54,22 @@ export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOpti
     }
   }
 
-  renderTypeSignature(type: CommonModel | CommonModel[], isRequired = true): string {
+  renderTypeSignature(type: CommonModel | CommonModel[], {
+    isRequired = true,
+    orUndefined = false,
+  }: {
+    isRequired?: boolean;
+    orUndefined?: boolean;
+  } = {}): string {
     if (this.options.renderTypes === false) {
       return '';
     }
+
     const annotation = isRequired ? ':' : '?:';
-    return `${annotation} ${this.renderType(type)}`;
+    let t = this.renderType(type);
+    t = orUndefined ? `${t} | undefined` : t;
+
+    return `${annotation} ${t}`;
   }
 
   renderComments(lines: string | string[]): string {
@@ -74,20 +84,20 @@ ${lines.map(line => ` * ${line}`).join('\n')}
     const content: string[] = [];
 
     for (const [propertyName, property] of Object.entries(properties)) {
-      const rendererProperty = await this.runPropertyPreset(propertyName, property, this.model);
+      const rendererProperty = await this.runPropertyPreset(propertyName, property);
       content.push(rendererProperty);
     }
 
     return this.renderBlock(content);
   }
 
-  renderProperty(propertyName: string, property: CommonModel, parentModel: CommonModel): string {
+  renderProperty(propertyName: string, property: CommonModel): string {
     const name = FormatHelpers.toCamelCase(propertyName);
-    const signature = this.renderTypeSignature(property, parentModel.isRequired(propertyName));
+    const signature = this.renderTypeSignature(property, { isRequired: this.model.isRequired(propertyName) });
     return `${name}${signature};`;
   }
 
-  async runPropertyPreset(propertyName: string, property: CommonModel, parentModel: CommonModel): Promise<string> {
-    return this.runPreset('property', { propertyName, property, parentModel });
+  async runPropertyPreset(propertyName: string, property: CommonModel): Promise<string> {
+    return this.runPreset('property', { propertyName, property });
   }
 }

--- a/src/generators/typescript/renderers/ClassRenderer.ts
+++ b/src/generators/typescript/renderers/ClassRenderer.ts
@@ -17,7 +17,8 @@ export class ClassRenderer extends TypeScriptRenderer {
       await this.runAdditionalContentPreset(),
     ];
 
-    return `class ${this.model.$id} {
+    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    return `class ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}
 }`;
   }
@@ -31,20 +32,20 @@ ${this.indent(this.renderBlock(content, 2))}
     const content: string[] = [];
 
     for (const [propertyName, property] of Object.entries(properties)) {
-      const getter = await this.runGetterPreset(propertyName, property, this.model);
-      const setter = await this.runSetterPreset(propertyName, property, this.model);
+      const getter = await this.runGetterPreset(propertyName, property);
+      const setter = await this.runSetterPreset(propertyName, property);
       content.push(this.renderBlock([getter, setter]));
     }
 
     return this.renderBlock(content, 2);
   }
 
-  runGetterPreset(propertyName: string, property: CommonModel, parentModel: CommonModel): Promise<string> {
-    return this.runPreset('getter', { propertyName, property, parentModel });
+  runGetterPreset(propertyName: string, property: CommonModel): Promise<string> {
+    return this.runPreset('getter', { propertyName, property });
   }
 
-  runSetterPreset(propertyName: string, property: CommonModel, parentModel: CommonModel): Promise<string> {
-    return this.runPreset('setter', { propertyName, property, parentModel });
+  runSetterPreset(propertyName: string, property: CommonModel): Promise<string> {
+    return this.runPreset('setter', { propertyName, property });
   }
 }
 
@@ -60,7 +61,7 @@ export const TS_DEFAULT_CLASS_PRESET: ClassPreset<ClassRenderer> = {
     });
     const ctorProperties: string[] = [];
     for (const [propertyName, property] of Object.entries(properties)) {
-      const rendererProperty = renderer.renderProperty(propertyName, property, model).replace(';', ',');
+      const rendererProperty = renderer.renderProperty(propertyName, property).replace(';', ',');
       ctorProperties.push(rendererProperty);
     }
 
@@ -70,18 +71,20 @@ ${renderer.indent(renderer.renderBlock(ctorProperties))}
 ${renderer.indent(renderer.renderBlock(assigments))}
 }`;
   },
-  property({ renderer, propertyName, property, parentModel }) {
-    return `private _${renderer.renderProperty(propertyName, property, parentModel)}`;
+  property({ renderer, propertyName, property }) {
+    return `private _${renderer.renderProperty(propertyName, property)}`;
   },
-  getter({ renderer, propertyName, property }) {
-    propertyName = FormatHelpers.toCamelCase(propertyName);
-    const signature = renderer.renderTypeSignature(property);
-    return `get ${propertyName}()${signature} { return this._${propertyName}; }`;
+  getter({ renderer, model, propertyName, property }) {
+    const isRequired = model.isRequired(propertyName);
+    const formattedName = FormatHelpers.toCamelCase(propertyName);
+    const signature = renderer.renderTypeSignature(property, { orUndefined: !isRequired });
+    return `get ${formattedName}()${signature} { return this._${formattedName}; }`;
   },
-  setter({ renderer, propertyName, property }) {
-    propertyName = FormatHelpers.toCamelCase(propertyName);
-    const signature = renderer.renderTypeSignature(property);
-    const arg = `${propertyName}${signature}`;
-    return `set ${propertyName}(${arg}) { this._${propertyName} = ${propertyName}; }`;
+  setter({ renderer, model, propertyName, property }) {
+    const isRequired = model.isRequired(propertyName);
+    const formattedName = FormatHelpers.toCamelCase(propertyName);
+    const signature = renderer.renderTypeSignature(property, { orUndefined: !isRequired });
+    const arg = `${formattedName}${signature}`;
+    return `set ${formattedName}(${arg}) { this._${formattedName} = ${formattedName}; }`;
   },
 };

--- a/src/generators/typescript/renderers/EnumRenderer.ts
+++ b/src/generators/typescript/renderers/EnumRenderer.ts
@@ -1,6 +1,6 @@
 import { TypeScriptRenderer } from '../TypeScriptRenderer';
 
-import { CommonModel, EnumPreset } from '../../../models';
+import { EnumPreset } from '../../../models';
 import { FormatHelpers } from '../../../helpers';
 
 /**
@@ -15,7 +15,8 @@ export class EnumRenderer extends TypeScriptRenderer {
       await this.runAdditionalContentPreset(),
     ];
 
-    return `enum ${this.model.$id} {
+    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    return `enum ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}
 }`;
   }
@@ -25,15 +26,15 @@ ${this.indent(this.renderBlock(content, 2))}
     const items: string[] = [];
 
     for (const item of enums) {
-      const renderedItem = await this.runItemPreset(item, this.model);
+      const renderedItem = await this.runItemPreset(item);
       items.push(renderedItem);
     }
 
     return this.renderBlock(items);
   }
 
-  runItemPreset(item: any, parentModel: CommonModel): Promise<string> {
-    return this.runPreset('item', { item, parentModel });
+  runItemPreset(item: any): Promise<string> {
+    return this.runPreset('item', { item });
   }
 }
 

--- a/src/generators/typescript/renderers/InterfaceRenderer.ts
+++ b/src/generators/typescript/renderers/InterfaceRenderer.ts
@@ -1,6 +1,7 @@
 import { TypeScriptRenderer } from '../TypeScriptRenderer';
 
 import { InterfacePreset } from '../../../models';
+import { FormatHelpers } from '../../../helpers';
 
 /**
  * Renderer for TypeScript's `interface` type
@@ -14,7 +15,8 @@ export class InterfaceRenderer extends TypeScriptRenderer {
       await this.runAdditionalContentPreset(),
     ];
 
-    return `interface ${this.model.$id} {
+    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    return `interface ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}
 }`;
   }
@@ -24,7 +26,7 @@ export const TS_DEFAULT_INTERFACE_PRESET: InterfacePreset<InterfaceRenderer> = {
   async self({ renderer }) {
     return `export ${await renderer.defaultSelf()}`;
   },
-  property({ renderer, propertyName, property, parentModel }) {
-    return renderer.renderProperty(propertyName, property, parentModel);
+  property({ renderer, propertyName, property }) {
+    return renderer.renderProperty(propertyName, property);
   },
 };

--- a/src/generators/typescript/renderers/TypeRenderer.ts
+++ b/src/generators/typescript/renderers/TypeRenderer.ts
@@ -1,7 +1,7 @@
 import { TypeScriptRenderer } from '../TypeScriptRenderer';
 
-import { TypeHelpers, ModelKind } from '../../../helpers';
 import { TypePreset } from '../TypeScriptPreset';
+import { FormatHelpers, TypeHelpers, ModelKind } from '../../../helpers';
 
 /**
  * Renderer for TypeScript's `type` type
@@ -11,7 +11,8 @@ import { TypePreset } from '../TypeScriptPreset';
 export class TypeRenderer extends TypeScriptRenderer {
   async defaultSelf(): Promise<string> {
     const body = await this.renderTypeBody();
-    return `type ${this.model.$id} = ${body};`;
+    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    return `type ${formattedName} = ${body};`;
   }
 
   async renderTypeBody(): Promise<string> {

--- a/src/models/Preset.ts
+++ b/src/models/Preset.ts
@@ -16,7 +16,6 @@ export interface CommonPreset<R extends AbstractRenderer, O extends object = any
 }
 
 export interface PropertyArgs {
-  parentModel: CommonModel;
   propertyName: string;
   property: CommonModel;
 }
@@ -33,7 +32,6 @@ export interface InterfacePreset<R extends AbstractRenderer, O extends object = 
 }
 
 export interface EnumArgs {
-  parentModel: CommonModel;
   item: any;
 }
 

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -83,17 +83,17 @@ describe('TypeScriptGenerator', function() {
     generator = new JavaGenerator({ presets: [
       {
         class: {
-          property({ propertyName, content }) {
-            return `@JsonProperty("${propertyName}")
-${content}`;
+          property({ renderer, propertyName, content }) {
+            const annotation = renderer.renderAnnotation('JsonProperty', `"${propertyName}"`);
+            return `${annotation}\n${content}`;
           },
-          getter({ propertyName, content }) {
-            return `@JsonProperty("${propertyName}")
-${content}`;
+          getter({ renderer, propertyName, content }) {
+            const annotation = renderer.renderAnnotation('JsonProperty', `"${propertyName}"`);
+            return `${annotation}\n${content}`;
           },
-          setter({ propertyName, content }) {
-            return `@JsonProperty("${propertyName}")
-${content}`;
+          setter({ renderer, propertyName, content }) {
+            const annotation = renderer.renderAnnotation('JsonProperty', `"${propertyName}"`);
+            return `${annotation}\n${content}`;
           },
         }
       }
@@ -287,8 +287,9 @@ public enum CustomEnum {
     generator = new JavaGenerator({ presets: [
       {
         enum: {
-          self({ content }) {
-            return `@EnumAnnotation\n${content}`;
+          self({ renderer, content }) {
+            const annotation = renderer.renderAnnotation('EnumAnnotation');
+            return `${annotation}\n${content}`;
           },
         }
       }

--- a/test/generators/typescript/TypeScriptGenerator.spec.ts
+++ b/test/generators/typescript/TypeScriptGenerator.spec.ts
@@ -8,7 +8,7 @@ describe('TypeScriptGenerator', function() {
 
   test('should render `class` type', async function() {
     const doc = {
-      $id: "Address",
+      $id: "_address",
       type: "object",
       properties: {
         street_name:    { type: "string" },
@@ -60,18 +60,18 @@ describe('TypeScriptGenerator', function() {
   get houseNumber(): number { return this._houseNumber; }
   set houseNumber(houseNumber: number) { this._houseNumber = houseNumber; }
 
-  get marriage(): boolean { return this._marriage; }
-  set marriage(marriage: boolean) { this._marriage = marriage; }
+  get marriage(): boolean | undefined { return this._marriage; }
+  set marriage(marriage: boolean | undefined) { this._marriage = marriage; }
 
-  get members(): string | number | boolean { return this._members; }
-  set members(members: string | number | boolean) { this._members = members; }
+  get members(): string | number | boolean | undefined { return this._members; }
+  set members(members: string | number | boolean | undefined) { this._members = members; }
 
   get arrayType(): Array<string | number> { return this._arrayType; }
   set arrayType(arrayType: Array<string | number>) { this._arrayType = arrayType; }
 }`;
 
     const inputModel = await generator.process(doc);
-    const model = inputModel.models["Address"];
+    const model = inputModel.models["_address"];
 
     let classModel = await generator.renderClass(model, inputModel);
     expect(classModel).toEqual(expected);
@@ -98,8 +98,8 @@ describe('TypeScriptGenerator', function() {
     this._property = input.property;
   }
 
-  get property(): string { return this._property; }
-  set property(property: string) { this._property = property; }
+  get property(): string | undefined { return this._property; }
+  set property(property: string | undefined) { this._property = property; }
 }`;
 
     generator = new TypeScriptGenerator({ presets: [


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Fix issue https://github.com/asyncapi/generator-model-sdk/issues/98
- PascalCase model's name.
- Remove `parentModel` argument - we have `model` and it's the same
- Add missed two function in JavaRenderer: `renderComments` and fix `renderAnnotation`.
- Render type by `format` property if exists in JavaRenderer.
- Update unit tests 

**Related issue(s)**
Resolves https://github.com/asyncapi/generator-model-sdk/issues/98