### PR TITLE
feat: add support function to get all CommonModel dependencies

### DIFF
--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -8,8 +8,8 @@ import { Schema } from './Schema';
  * @extends CommonSchema<CommonModel>
  */
 export class CommonModel extends CommonSchema<CommonModel> {
-  extend?: string[]
-  originalSchema?: Schema | boolean
+  extend?: string[];
+  originalSchema?: Schema | boolean;
   
   /**
    * Transform object into a type of CommonModel.
@@ -172,29 +172,31 @@ export class CommonModel extends CommonSchema<CommonModel> {
   }
 
   /**
-   * This function returns an array of all the other models it depends on.
+   * This function returns an array of `$id`s from all the CommonModel's it immediate depends on.
    */
-  getDependsOn(): string[] {
+  getImmediateDependencies(): string[] {
     const dependsOn = [];
     if (this.additionalProperties instanceof CommonModel) {
       const additionalPropertiesRef = (this.additionalProperties as CommonModel).$ref;
       if (additionalPropertiesRef !== undefined) {
-        const filename = FormatHelpers.toPascalCase(additionalPropertiesRef);
-        dependsOn.push(filename);
+        dependsOn.push(additionalPropertiesRef);
+      }
+    }
+    if (this.extend !== undefined) {
+      for (const extendedSchema of this.extend) {
+        dependsOn.push(extendedSchema);
       }
     }
     if (this.items instanceof CommonModel) {
       const itemsRef = (this.items as CommonModel).$ref;
       if (itemsRef !== undefined) {
-        const filename = FormatHelpers.toPascalCase(itemsRef);
-        dependsOn.push(filename);
+        dependsOn.push(itemsRef);
       }
     }
     if (this.properties !== undefined && Object.keys(this.properties).length) {
       Object.entries(this.properties).forEach(([, propertyModel]) => {
         if (propertyModel.$ref !== undefined) {
-          const filename = FormatHelpers.toPascalCase(propertyModel.$ref);
-          dependsOn.push(filename);
+          dependsOn.push(propertyModel.$ref);
         }
       });
     }

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -1,3 +1,4 @@
+import { FormatHelpers } from '../helpers/FormatHelpers';
 import { CommonSchema } from './CommonSchema';
 import { Schema } from './Schema';
 
@@ -168,5 +169,35 @@ export class CommonModel extends CommonSchema<CommonModel> {
       return false;
     }
     return this.required.includes(propertyName);
+  }
+
+  /**
+   * This function returns an array of all the other models it depends on.
+   */
+  getDependsOn(): string[] {
+    const dependsOn = [];
+    if (this.additionalProperties instanceof CommonModel) {
+      const additionalPropertiesRef = (this.additionalProperties as CommonModel).$ref;
+      if (additionalPropertiesRef !== undefined) {
+        const filename = FormatHelpers.toPascalCase(additionalPropertiesRef);
+        dependsOn.push(filename);
+      }
+    }
+    if (this.items instanceof CommonModel) {
+      const itemsRef = (this.items as CommonModel).$ref;
+      if (itemsRef !== undefined) {
+        const filename = FormatHelpers.toPascalCase(itemsRef);
+        dependsOn.push(filename);
+      }
+    }
+    if (this.properties !== undefined && Object.keys(this.properties).length) {
+      Object.entries(this.properties).forEach(([_, propertyModel]) => {
+        if (propertyModel.$ref !== undefined) {
+          const filename = FormatHelpers.toPascalCase(propertyModel.$ref);
+          dependsOn.push(filename);
+        }
+      });
+    }
+    return dependsOn;
   }
 }

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -1,4 +1,3 @@
-import { FormatHelpers } from '../helpers/FormatHelpers';
 import { CommonSchema } from './CommonSchema';
 import { Schema } from './Schema';
 

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -191,7 +191,7 @@ export class CommonModel extends CommonSchema<CommonModel> {
       }
     }
     if (this.properties !== undefined && Object.keys(this.properties).length) {
-      Object.entries(this.properties).forEach(([_, propertyModel]) => {
+      Object.entries(this.properties).forEach(([, propertyModel]) => {
         if (propertyModel.$ref !== undefined) {
           const filename = FormatHelpers.toPascalCase(propertyModel.$ref);
           dependsOn.push(filename);

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -396,9 +396,9 @@ describe('CommonModel', function() {
 
     describe('getImmediateDependencies', function() {
       test('check that all dependencies are returned', function() {
-        const doc = { additionalProperties: { $ref: "1" }, items: { $ref: "2" }, properties: { testProp: { $ref: "3" } }  };
+        const doc = { additionalProperties: { $ref: "1" }, extend: ["2"], items: { $ref: "3" }, properties: { testProp: { $ref: "4" } }  };
         const d = CommonModel.toCommonModel(doc);
-        expect(d.getImmediateDependencies()).toEqual(["1", "2", "3"]);
+        expect(d.getImmediateDependencies()).toEqual(["1", "2", "3", "4"]);
       });
       test('check that no dependencies is returned if there are none', function() {
         const doc = {  };

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -394,16 +394,16 @@ describe('CommonModel', function() {
       });
     });
 
-    describe('getDependsOn', function() {
+    describe('getImmediateDependencies', function() {
       test('check that all dependencies are returned', function() {
         const doc = { additionalProperties: { $ref: "1" }, items: { $ref: "2" }, properties: { testProp: { $ref: "3" } }  };
         const d = CommonModel.toCommonModel(doc);
-        expect(d.getDependsOn()).toEqual(["1", "2", "3"]);
+        expect(d.getImmediateDependencies()).toEqual(["1", "2", "3"]);
       });
       test('check that no dependencies is returned if there are none', function() {
         const doc = {  };
         const d = CommonModel.toCommonModel(doc);
-        expect(d.getDependsOn()).toEqual([]);
+        expect(d.getImmediateDependencies()).toEqual([]);
       });
     });
   });

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -393,5 +393,18 @@ describe('CommonModel', function() {
         expect(d.isRequired("propX")).toEqual(false);
       });
     });
+
+    describe('getDependsOn', function() {
+      test('check that all dependencies are returned', function() {
+        const doc = { additionalProperties: { $ref: "1" }, items: { $ref: "2" }, properties: { testProp: { $ref: "3" } }  };
+        const d = CommonModel.toCommonModel(doc);
+        expect(d.getDependsOn()).toEqual(["1", "2", "3"]);
+      });
+      test('check that no dependencies is returned if there are none', function() {
+        const doc = {  };
+        const d = CommonModel.toCommonModel(doc);
+        expect(d.getDependsOn()).toEqual([]);
+      });
+    });
   });
 });


### PR DESCRIPTION
**Description**
This PR adds a helper function to CommonModel which returns all references to other CommonModels. This is useful when you want to add imports and split the models into separate files.
