### PR TITLE
fix: switch to merging allOf keywords instead of extending them

### DIFF
--- a/src/simplification/Simplifier.ts
+++ b/src/simplification/Simplifier.ts
@@ -12,7 +12,7 @@ import simplifyName from './SimplifyName';
 
 export class Simplifier {
   static defaultOptions: SimplificationOptions = {
-    allowInheritance: true
+    allowInheritance: false
   }
 
   private anonymCounter = 1;
@@ -148,7 +148,7 @@ export class Simplifier {
  * 
  * @param schema to simplify
  */
-export function simplify(schema: Schema | boolean): CommonModel[] {
-  const simplifier = new Simplifier();
+export function simplify(schema: Schema | boolean, options?: SimplificationOptions): CommonModel[] {
+  const simplifier = new Simplifier(options);
   return simplifier.simplify(schema);
 }

--- a/test/processors/JsonSchemaInputProcessor/commonInputModel/combination_schemas.json
+++ b/test/processors/JsonSchemaInputProcessor/commonInputModel/combination_schemas.json
@@ -1,66 +1,66 @@
 {
-  "models": {
-    "root": {
-      "originalSchema": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "type": "object",
-        "properties": {
-          "shipping_address": {
-            "allOf": [
+  "models":{
+    "root":{
+      "originalSchema":{
+        "$schema":"http://json-schema.org/draft-07/schema#",
+        "type":"object",
+        "properties":{
+          "shipping_address":{
+            "allOf":[
               {
-                "type": "object",
-                "properties": {
-                  "street_address": {
-                    "type": "string",
-                    "x-modelgen-inferred-name": "shipping_address_allOf_0_street_address"
+                "type":"object",
+                "properties":{
+                  "street_address":{
+                    "type":"string",
+                    "x-modelgen-inferred-name":"shipping_address_allOf_0_street_address"
                   },
-                  "city": {
-                    "type": "string",
-                    "x-modelgen-inferred-name": "shipping_address_allOf_0_city"
+                  "city":{
+                    "type":"string",
+                    "x-modelgen-inferred-name":"shipping_address_allOf_0_city"
                   },
-                  "state": {
-                    "type": "string",
-                    "x-modelgen-inferred-name": "shipping_address_allOf_0_state"
+                  "state":{
+                    "type":"string",
+                    "x-modelgen-inferred-name":"shipping_address_allOf_0_state"
                   }
                 },
-                "required": [
+                "required":[
                   "street_address",
                   "city",
                   "state"
                 ],
-                "x-modelgen-inferred-name": "shipping_address_allOf_0"
+                "x-modelgen-inferred-name":"shipping_address_allOf_0"
               },
               {
-                "properties": {
-                  "type": {
-                    "enum": [
+                "properties":{
+                  "type":{
+                    "enum":[
                       "residential",
                       "business"
                     ],
-                    "x-modelgen-inferred-name": "shipping_address_allOf_1_type"
+                    "x-modelgen-inferred-name":"shipping_address_allOf_1_type"
                   }
                 },
-                "required": [
+                "required":[
                   "type"
                 ],
-                "x-modelgen-inferred-name": "shipping_address_allOf_1"
+                "x-modelgen-inferred-name":"shipping_address_allOf_1"
               }
             ],
-            "x-modelgen-inferred-name": "shipping_address"
+            "x-modelgen-inferred-name":"shipping_address"
           }
         },
-        "x-modelgen-inferred-name": "root"
+        "x-modelgen-inferred-name":"root"
       },
-      "type": "object",
-      "$id": "root",
-      "properties": {
-        "shipping_address": {
-          "$ref": "shipping_address"
+      "type":"object",
+      "$id":"root",
+      "properties":{
+        "shipping_address":{
+          "$ref":"shipping_address"
         }
       },
-      "additionalProperties": {
-        "originalSchema": true,
-        "type": [
+      "additionalProperties":{
+        "originalSchema":true,
+        "type":[
           "object",
           "string",
           "number",
@@ -70,109 +70,92 @@
         ]
       }
     },
-    "shipping_address_allOf_0": {
-      "originalSchema": {
-        "type": "object",
-        "properties": {
-          "street_address": {
-            "type": "string",
-            "x-modelgen-inferred-name": "shipping_address_allOf_0_street_address"
+    "shipping_address":{
+      "originalSchema":{
+        "allOf":[
+          {
+            "type":"object",
+            "properties":{
+              "street_address":{
+                "type":"string",
+                "x-modelgen-inferred-name":"shipping_address_allOf_0_street_address"
+              },
+              "city":{
+                "type":"string",
+                "x-modelgen-inferred-name":"shipping_address_allOf_0_city"
+              },
+              "state":{
+                "type":"string",
+                "x-modelgen-inferred-name":"shipping_address_allOf_0_state"
+              }
+            },
+            "required":[
+              "street_address",
+              "city",
+              "state"
+            ],
+            "x-modelgen-inferred-name":"shipping_address_allOf_0"
           },
-          "city": {
-            "type": "string",
-            "x-modelgen-inferred-name": "shipping_address_allOf_0_city"
-          },
-          "state": {
-            "type": "string",
-            "x-modelgen-inferred-name": "shipping_address_allOf_0_state"
+          {
+            "properties":{
+              "type":{
+                "enum":[
+                  "residential",
+                  "business"
+                ],
+                "x-modelgen-inferred-name":"shipping_address_allOf_1_type"
+              }
+            },
+            "required":[
+              "type"
+            ],
+            "x-modelgen-inferred-name":"shipping_address_allOf_1"
           }
-        },
-        "required": [
-          "street_address",
-          "city",
-          "state"
         ],
-        "x-modelgen-inferred-name": "shipping_address_allOf_0"
+        "x-modelgen-inferred-name":"shipping_address"
       },
-      "type": "object",
-      "$id": "shipping_address_allOf_0",
-      "properties": {
-        "street_address": {
-          "originalSchema": {
-            "type": "string",
-            "x-modelgen-inferred-name": "shipping_address_allOf_0_street_address"
+      "type":"object",
+      "$id":"shipping_address",
+      "properties":{
+        "street_address":{
+          "originalSchema":{
+            "type":"string",
+            "x-modelgen-inferred-name":"shipping_address_allOf_0_street_address"
           },
-          "type": "string"
+          "type":"string"
         },
-        "city": {
-          "originalSchema": {
-            "type": "string",
-            "x-modelgen-inferred-name": "shipping_address_allOf_0_city"
+        "city":{
+          "originalSchema":{
+            "type":"string",
+            "x-modelgen-inferred-name":"shipping_address_allOf_0_city"
           },
-          "type": "string"
+          "type":"string"
         },
-        "state": {
-          "originalSchema": {
-            "type": "string",
-            "x-modelgen-inferred-name": "shipping_address_allOf_0_state"
+        "state":{
+          "originalSchema":{
+            "type":"string",
+            "x-modelgen-inferred-name":"shipping_address_allOf_0_state"
           },
-          "type": "string"
-        }
-      },
-      "additionalProperties": {
-        "originalSchema": true,
-        "type": [
-          "object",
-          "string",
-          "number",
-          "array",
-          "boolean",
-          "null"
-        ]
-      },
-      "required": [
-        "street_address",
-        "city",
-        "state"
-      ]
-    },
-    "shipping_address_allOf_1": {
-      "originalSchema": {
-        "properties": {
-          "type": {
-            "enum": [
+          "type":"string"
+        },
+        "type":{
+          "originalSchema":{
+            "enum":[
               "residential",
               "business"
             ],
-            "x-modelgen-inferred-name": "shipping_address_allOf_1_type"
-          }
-        },
-        "required": [
-          "type"
-        ],
-        "x-modelgen-inferred-name": "shipping_address_allOf_1"
-      },
-      "type": "object",
-      "$id": "shipping_address_allOf_1",
-      "properties": {
-        "type": {
-          "originalSchema": {
-            "enum": [
-              "residential",
-              "business"
-            ],
-            "x-modelgen-inferred-name": "shipping_address_allOf_1_type"
+            "x-modelgen-inferred-name":"shipping_address_allOf_1_type"
           },
-          "type": "string",
-          "enum": [
+          "type":"string",
+          "enum":[
             "residential",
             "business"
           ]
         }
       },
-      "additionalProperties": {
-        "originalSchema": true,
-        "type": [
+      "additionalProperties":{
+        "originalSchema":true,
+        "type":[
           "object",
           "string",
           "number",
@@ -181,72 +164,7 @@
           "null"
         ]
       },
-      "required": [
-        "type"
-      ]
-    },
-    "shipping_address": {
-      "originalSchema": {
-        "allOf": [
-          {
-            "type": "object",
-            "properties": {
-              "street_address": {
-                "type": "string",
-                "x-modelgen-inferred-name": "shipping_address_allOf_0_street_address"
-              },
-              "city": {
-                "type": "string",
-                "x-modelgen-inferred-name": "shipping_address_allOf_0_city"
-              },
-              "state": {
-                "type": "string",
-                "x-modelgen-inferred-name": "shipping_address_allOf_0_state"
-              }
-            },
-            "required": [
-              "street_address",
-              "city",
-              "state"
-            ],
-            "x-modelgen-inferred-name": "shipping_address_allOf_0"
-          },
-          {
-            "properties": {
-              "type": {
-                "enum": [
-                  "residential",
-                  "business"
-                ],
-                "x-modelgen-inferred-name": "shipping_address_allOf_1_type"
-              }
-            },
-            "required": [
-              "type"
-            ],
-            "x-modelgen-inferred-name": "shipping_address_allOf_1"
-          }
-        ],
-        "x-modelgen-inferred-name": "shipping_address"
-      },
-      "type": "object",
-      "$id": "shipping_address",
-      "additionalProperties": {
-        "originalSchema": true,
-        "type": [
-          "object",
-          "string",
-          "number",
-          "array",
-          "boolean",
-          "null"
-        ]
-      },
-      "extend": [
-        "shipping_address_allOf_0",
-        "shipping_address_allOf_1"
-      ],
-      "required": [
+      "required":[
         "street_address",
         "city",
         "state",
@@ -254,55 +172,57 @@
       ]
     }
   },
-  "customizations": {},
-  "originalInput": {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-      "shipping_address": {
-        "allOf": [
+  "customizations":{
+    
+  },
+  "originalInput":{
+    "$schema":"http://json-schema.org/draft-07/schema#",
+    "type":"object",
+    "properties":{
+      "shipping_address":{
+        "allOf":[
           {
-            "type": "object",
-            "properties": {
-              "street_address": {
-                "type": "string",
-                "x-modelgen-inferred-name": "shipping_address_allOf_0_street_address"
+            "type":"object",
+            "properties":{
+              "street_address":{
+                "type":"string",
+                "x-modelgen-inferred-name":"shipping_address_allOf_0_street_address"
               },
-              "city": {
-                "type": "string",
-                "x-modelgen-inferred-name": "shipping_address_allOf_0_city"
+              "city":{
+                "type":"string",
+                "x-modelgen-inferred-name":"shipping_address_allOf_0_city"
               },
-              "state": {
-                "type": "string",
-                "x-modelgen-inferred-name": "shipping_address_allOf_0_state"
+              "state":{
+                "type":"string",
+                "x-modelgen-inferred-name":"shipping_address_allOf_0_state"
               }
             },
-            "required": [
+            "required":[
               "street_address",
               "city",
               "state"
             ],
-            "x-modelgen-inferred-name": "shipping_address_allOf_0"
+            "x-modelgen-inferred-name":"shipping_address_allOf_0"
           },
           {
-            "properties": {
-              "type": {
-                "enum": [
+            "properties":{
+              "type":{
+                "enum":[
                   "residential",
                   "business"
                 ],
-                "x-modelgen-inferred-name": "shipping_address_allOf_1_type"
+                "x-modelgen-inferred-name":"shipping_address_allOf_1_type"
               }
             },
-            "required": [
+            "required":[
               "type"
             ],
-            "x-modelgen-inferred-name": "shipping_address_allOf_1"
+            "x-modelgen-inferred-name":"shipping_address_allOf_1"
           }
         ],
-        "x-modelgen-inferred-name": "shipping_address"
+        "x-modelgen-inferred-name":"shipping_address"
       }
     },
-    "x-modelgen-inferred-name": "root"
+    "x-modelgen-inferred-name":"root"
   }
 }

--- a/test/processors/JsonSchemaInputProcessor/commonInputModel/references_circular_allOf.json
+++ b/test/processors/JsonSchemaInputProcessor/commonInputModel/references_circular_allOf.json
@@ -3,17 +3,6 @@
     "root":{
       "type":"object",
       "$id":"root",
-      "additionalProperties": {
-        "originalSchema": true,
-        "type": [
-          "object",
-          "string",
-          "number",
-          "array",
-          "boolean",
-          "null"
-        ]
-      },
       "properties":{
         "street_address":{
           "$ref":"street_address"
@@ -23,7 +12,8 @@
             "enum":[
               "United States of America",
               "Canada"
-            ]
+            ],
+            "x-modelgen-inferred-name":"country"
           },
           "type":"string",
           "enum":[
@@ -31,53 +21,50 @@
             "Canada"
           ]
         }
+      },
+      "additionalProperties":{
+        "originalSchema":true,
+        "type":[
+          "object",
+          "string",
+          "number",
+          "array",
+          "boolean",
+          "null"
+        ]
       }
     },
-    "street_address":{
+    "test2_floor2":{
       "type":"object",
-      "$id":"street_address",
-      "additionalProperties": {
-        "originalSchema": true,
-        "type": [
-          "object",
-          "string",
-          "number",
-          "array",
-          "boolean",
-          "null"
-        ]
-      },
-      "extend":[
-        "test_allOf_0",
-        "test_allOf_1"
-      ]
-    },
-    "test_allOf_0":{
-      "type":"object",
-      "$id":"test_allOf_0",
-      "additionalProperties": {
-        "originalSchema": true,
-        "type": [
-          "object",
-          "string",
-          "number",
-          "array",
-          "boolean",
-          "null"
-        ]
-      },
+      "$id":"test2_floor2",
       "properties":{
-        "floor":{
-          "$ref":"test_allOf_0_floor"
+        "floor2":{
+          "$ref":"test2_floor2"
         }
+      },
+      "additionalProperties":{
+        "originalSchema":true,
+        "type":[
+          "object",
+          "string",
+          "number",
+          "array",
+          "boolean",
+          "null"
+        ]
       }
     },
     "test_allOf_0_floor":{
       "type":"object",
       "$id":"test_allOf_0_floor",
-      "additionalProperties": {
-        "originalSchema": true,
-        "type": [
+      "properties":{
+        "floor2":{
+          "$ref":"test2_floor2"
+        }
+      },
+      "additionalProperties":{
+        "originalSchema":true,
+        "type":[
           "object",
           "string",
           "number",
@@ -85,53 +72,33 @@
           "boolean",
           "null"
         ]
-      },
+      }
+    },
+    "street_address":{
+      "type":"object",
+      "$id":"street_address",
       "properties":{
+        "floor":{
+          "$ref":"test_allOf_0_floor"
+        },
         "floor2":{
           "$ref":"test2_floor2"
         }
+      },
+      "additionalProperties":{
+        "originalSchema":true,
+        "type":[
+          "object",
+          "string",
+          "number",
+          "array",
+          "boolean",
+          "null"
+        ]
       }
     }
   },
   "customizations":{
     
-  },
-  "originalInput":{
-    "definitions":{
-      "test2":{
-        "properties":{
-          "floor2":{
-            "$ref":"#/definitions/test2"
-          }
-        }
-      },
-      "test":{
-        "type":"object",
-        "allOf":[
-          {
-            "properties":{
-              "floor":{
-                "$ref":"#/definitions/test2"
-              }
-            }
-          },
-          {
-            "$ref":"#/definitions/test2"
-          }
-        ]
-      }
-    },
-    "type":"object",
-    "properties":{
-      "street_address":{
-        "$ref":"#/definitions/test"
-      },
-      "country":{
-        "enum":[
-          "United States of America",
-          "Canada"
-        ]
-      }
-    }
   }
 }

--- a/test/simplification/extends.spec.ts
+++ b/test/simplification/extends.spec.ts
@@ -12,7 +12,7 @@ describe('Simplification to extend', function() {
     const expectedSchemaString = fs.readFileSync(path.resolve(__dirname, './extends/expected/extend.json'), 'utf8');
     const schema = JSON.parse(inputSchemaString);
     const expectedModels = JSON.parse(expectedSchemaString);
-    const actualModels = simplify(schema);
+    const actualModels = simplify(schema, {allowInheritance: true});
     expect(actualModels).toMatchObject(expectedModels);
     expect(schema.$id).toBeUndefined();
   });
@@ -22,7 +22,7 @@ describe('Simplification to extend', function() {
     const expectedSchemaString = fs.readFileSync(path.resolve(__dirname, './extends/expected/extendMultipleObjects.json'), 'utf8');
     const schema = JSON.parse(inputSchemaString);
     const expectedModels = JSON.parse(expectedSchemaString);
-    const actualModels = simplify(schema);
+    const actualModels = simplify(schema, {allowInheritance: true});
     expect(actualModels).toMatchObject(expectedModels);
     expect(schema.$id).toBeUndefined();
   });
@@ -32,7 +32,7 @@ describe('Simplification to extend', function() {
     const expectedSchemaString = fs.readFileSync(path.resolve(__dirname, './extends/expected/extendWithProperties.json'), 'utf8');
     const schema = JSON.parse(inputSchemaString);
     const expectedModels = JSON.parse(expectedSchemaString);
-    const actualModels = simplify(schema);
+    const actualModels = simplify(schema, {allowInheritance: true});
     expect(actualModels).toMatchObject(expectedModels);
     expect(schema.$id).toBeUndefined();
   });
@@ -42,7 +42,7 @@ describe('Simplification to extend', function() {
     const expectedSchemaString = fs.readFileSync(path.resolve(__dirname, './extends/expected/nestedExtends.json'), 'utf8');
     const schema = JSON.parse(inputSchemaString);
     const expectedModels = JSON.parse(expectedSchemaString);
-    const actualModels = simplify(schema);
+    const actualModels = simplify(schema, {allowInheritance: true});
     expect(actualModels).toMatchObject(expectedModels);
     expect(schema.$id).toBeUndefined();
   });


### PR DESCRIPTION
**Description**
This PR switches the default option from extending to merging.

**Related issue(s)**
fixes #107 