### PR TITLE
fix: remove customizations property from CommonInputModel class

### DIFF
--- a/src/models/CommonInputModel.ts
+++ b/src/models/CommonInputModel.ts
@@ -4,8 +4,6 @@ import { CommonModel } from './CommonModel';
  * This class is the wrapper for simplified models and the rest of the context needed for further generate typed models.
  */
 export class CommonInputModel {
-    models: {[key: string]: CommonModel} = {};
-    // TODO: Remove it and update tests
-    customizations: Object = {};
-    originalInput: any = {};
+  models: {[key: string]: CommonModel} = {};
+  originalInput: any = {};
 }

--- a/test/processors/AsyncAPIInputProcessor/commonInputModel/basic.json
+++ b/test/processors/AsyncAPIInputProcessor/commonInputModel/basic.json
@@ -38,9 +38,6 @@
       }
     }
   },
-  "customizations":{
-    
-  },
   "originalInput":{
     "_json":{
       "asyncapi":"2.0.0",

--- a/test/processors/JsonSchemaInputProcessor/commonInputModel/absence_type.json
+++ b/test/processors/JsonSchemaInputProcessor/commonInputModel/absence_type.json
@@ -37,7 +37,6 @@
       }
     }
   },
-  "customizations": {},
   "originalInput": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",

--- a/test/processors/JsonSchemaInputProcessor/commonInputModel/applying_conditional_schemas.json
+++ b/test/processors/JsonSchemaInputProcessor/commonInputModel/applying_conditional_schemas.json
@@ -121,7 +121,6 @@
       ]
     }
   },
-  "customizations": {},
   "originalInput": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",

--- a/test/processors/JsonSchemaInputProcessor/commonInputModel/combination_schemas.json
+++ b/test/processors/JsonSchemaInputProcessor/commonInputModel/combination_schemas.json
@@ -172,9 +172,6 @@
       ]
     }
   },
-  "customizations":{
-    
-  },
   "originalInput":{
     "$schema":"http://json-schema.org/draft-07/schema#",
     "type":"object",

--- a/test/processors/JsonSchemaInputProcessor/commonInputModel/enum.json
+++ b/test/processors/JsonSchemaInputProcessor/commonInputModel/enum.json
@@ -52,7 +52,6 @@
       }
     }
   },
-  "customizations": {},
   "originalInput": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",

--- a/test/processors/JsonSchemaInputProcessor/commonInputModel/items.json
+++ b/test/processors/JsonSchemaInputProcessor/commonInputModel/items.json
@@ -142,7 +142,6 @@
       }
     }
   },
-  "customizations": {},
   "originalInput": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",

--- a/test/processors/JsonSchemaInputProcessor/commonInputModel/multiple_objects.json
+++ b/test/processors/JsonSchemaInputProcessor/commonInputModel/multiple_objects.json
@@ -93,7 +93,6 @@
       }
     }
   },
-  "customizations": {},
   "originalInput": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",

--- a/test/processors/JsonSchemaInputProcessor/commonInputModel/object_property_with_anyOf.json
+++ b/test/processors/JsonSchemaInputProcessor/commonInputModel/object_property_with_anyOf.json
@@ -51,9 +51,6 @@
       }
     }
   },
-  "customizations":{
-    
-  },
   "originalInput":{
     "$schema":"http://json-schema.org/draft-07/schema#",
     "type":[

--- a/test/processors/JsonSchemaInputProcessor/commonInputModel/references.json
+++ b/test/processors/JsonSchemaInputProcessor/commonInputModel/references.json
@@ -104,7 +104,6 @@
       }
     }
   },
-  "customizations": {},
   "originalInput": {
     "definitions": {
       "test": {

--- a/test/processors/JsonSchemaInputProcessor/commonInputModel/references_circular.json
+++ b/test/processors/JsonSchemaInputProcessor/commonInputModel/references_circular.json
@@ -54,9 +54,6 @@
       }
     }
   },
-  "customizations":{
-    
-  },
   "originalInput":{
     "definitions":{
       "test":{

--- a/test/processors/JsonSchemaInputProcessor/commonInputModel/references_circular_allOf.json
+++ b/test/processors/JsonSchemaInputProcessor/commonInputModel/references_circular_allOf.json
@@ -97,8 +97,5 @@
         ]
       }
     }
-  },
-  "customizations":{
-    
   }
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As in title: remove `customizations` property from `CommonInputModel` class.