### PR TITLE
fix: some keywords are not iterated for AsyncAPI input

### DIFF
--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -95,16 +95,16 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
       }
     }
 
-    if (schema.properties !== null && Object.keys(schema.properties).length) {
+    if (schema.properties() !== null && Object.keys(schema.properties()).length) {
       const properties : {[key: string]: Schema | boolean} = {};
-      Object.entries(schema.properties).forEach(([propertyName, propertySchema]) => {
+      Object.entries(schema.properties()).forEach(([propertyName, propertySchema]) => {
         properties[`${propertyName}`] = this.reflectSchemaNames(propertySchema);
       });
       convertedSchema.properties = properties;
     }
-    if (schema.dependencies !== null && Object.keys(schema.dependencies).length) {
+    if (schema.dependencies() !== null && Object.keys(schema.dependencies()).length) {
       const dependencies: { [key: string]: Schema | boolean | string[] } = {};
-      Object.entries(schema.dependencies).forEach(([dependencyName, dependency]) => {
+      Object.entries(schema.dependencies()).forEach(([dependencyName, dependency]) => {
         if (typeof dependency === 'object' && !Array.isArray(dependency)) {
           dependencies[`${dependencyName}`] = this.reflectSchemaNames(dependency);
         } else {
@@ -113,16 +113,16 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
       });
       convertedSchema.dependencies = dependencies;
     }
-    if (schema.patternProperties !== null && Object.keys(schema.patternProperties).length) {
+    if (schema.patternProperties() !== null && Object.keys(schema.patternProperties()).length) {
       const patternProperties: { [key: string]: Schema | boolean } = {};
-      Object.entries(schema.patternProperties).forEach(([patternPropertyName, patternProperty]) => {
+      Object.entries(schema.patternProperties()).forEach(([patternPropertyName, patternProperty]) => {
         patternProperties[`${patternPropertyName}`] = this.reflectSchemaNames(patternProperty);
       });
       convertedSchema.patternProperties = patternProperties;
     }
-    if (schema.definitions !== null && Object.keys(schema.definitions).length) {
+    if (schema.definitions() !== null && Object.keys(schema.definitions()).length) {
       const definitions: { [key: string]: Schema | boolean } = {};
-      Object.entries(schema.definitions).forEach(([definitionName, definition]) => {
+      Object.entries(schema.definitions()).forEach(([definitionName, definition]) => {
         definitions[`${definitionName}`] = this.reflectSchemaNames(definition);
       });
       convertedSchema.definitions = definitions;

--- a/test/processors/AsyncAPIInputProcessor.spec.ts
+++ b/test/processors/AsyncAPIInputProcessor.spec.ts
@@ -50,4 +50,43 @@ describe('AsyncAPIInputProcessor', function() {
             expect(commonInputModel).toEqual(expectedCommonInputModel);
         });
     });
+
+    describe('reflectSchemaName()', function() {
+        test('should work', async function() {
+            const basicDocString = fs.readFileSync(path.resolve(__dirname, './AsyncAPIInputProcessor/schema_name_reflection.json'), 'utf8');
+            const doc = await parse(basicDocString);
+            const schema = doc.channels()["/user/signedup"].subscribe().message().payload();
+            const expected = AsyncAPIInputProcessor.reflectSchemaNames(schema) as any;
+
+            // root
+            expect(expected['x-modelgen-inferred-name']).toEqual('<anonymous-schema-1>');
+
+            // properties
+            expect(expected.properties.prop['x-modelgen-inferred-name']).toEqual('<anonymous-schema-2>');
+            expect(expected.properties.allOfCase['x-modelgen-inferred-name']).toEqual('<anonymous-schema-3>');
+            expect(expected.properties.allOfCase.allOf[0]['x-modelgen-inferred-name']).toEqual('<anonymous-schema-4>');
+            expect(expected.properties.allOfCase.allOf[1]['x-modelgen-inferred-name']).toEqual('<anonymous-schema-5>');
+            expect(expected.properties.object['x-modelgen-inferred-name']).toEqual('<anonymous-schema-6>');
+            expect(expected.properties.object.properties.prop['x-modelgen-inferred-name']).toEqual('<anonymous-schema-7>');
+            expect(expected.properties.propWithObject['x-modelgen-inferred-name']).toEqual('<anonymous-schema-8>');
+            expect(expected.properties.propWithObject.properties.propWithObject['x-modelgen-inferred-name']).toEqual('<anonymous-schema-9>');
+
+            // patternProperties
+            expect(expected.patternProperties.patternProp['x-modelgen-inferred-name']).toEqual('<anonymous-schema-10>');
+
+            // dependencies
+            expect(expected.dependencies.dep['x-modelgen-inferred-name']).toEqual('<anonymous-schema-11>');
+
+            // definitions
+            expect(expected.definitions.def['x-modelgen-inferred-name']).toEqual('<anonymous-schema-12>');
+            expect(expected.definitions.oneOfCase['x-modelgen-inferred-name']).toEqual('<anonymous-schema-13>');
+            expect(expected.definitions.oneOfCase.oneOf[0]['x-modelgen-inferred-name']).toEqual('<anonymous-schema-14>');
+            expect(expected.definitions.oneOfCase.oneOf[1]['x-modelgen-inferred-name']).toEqual('<anonymous-schema-15>');
+
+            // anyOf
+            expect(expected.anyOf[0]['x-modelgen-inferred-name']).toEqual('<anonymous-schema-16>');
+            expect(expected.anyOf[1]['x-modelgen-inferred-name']).toEqual('<anonymous-schema-17>');
+            expect(expected.anyOf[1].properties.prop['x-modelgen-inferred-name']).toEqual('<anonymous-schema-18>');
+        });
+    });
 });

--- a/test/processors/AsyncAPIInputProcessor/commonInputModel/basic.json
+++ b/test/processors/AsyncAPIInputProcessor/commonInputModel/basic.json
@@ -7,7 +7,8 @@
           "email":{
             "type":"string",
             "format":"email",
-            "x-parser-schema-id":"<anonymous-schema-2>"
+            "x-parser-schema-id":"<anonymous-schema-2>",
+            "x-modelgen-inferred-name": "<anonymous-schema-2>"
           }
         },
         "x-parser-schema-id":"<anonymous-schema-1>",
@@ -20,7 +21,8 @@
           "originalSchema":{
             "type":"string",
             "format":"email",
-            "x-parser-schema-id":"<anonymous-schema-2>"
+            "x-parser-schema-id":"<anonymous-schema-2>",
+            "x-modelgen-inferred-name": "<anonymous-schema-2>"
           },
           "type":"string"
         }

--- a/test/processors/AsyncAPIInputProcessor/schema_name_reflection.json
+++ b/test/processors/AsyncAPIInputProcessor/schema_name_reflection.json
@@ -1,0 +1,119 @@
+{
+  "asyncapi": "2.0.0",
+  "defaultContentType": "application/json",
+  "externalDocs": {
+    "description": "Find more info here",
+    "url": "https://example.com"
+  },
+  "tags": [
+    {
+      "name": "user",
+      "description": "user signed up"
+    },
+    {
+      "name": "signup"
+    }
+  ],
+  "info": {
+    "title": "Signup service example (internal)",
+    "version": "0.1.0"
+  },
+  "channels": {
+    "/user/signedup": {
+      "subscribe": {
+        "message": {
+          "payload": {
+            "type": "object",
+            "x-parser-schema-id": "<anonymous-schema-1>",
+            "properties": {
+              "prop": {
+                "x-parser-schema-id": "<anonymous-schema-2>",
+                "type": "string"
+              },
+              "allOfCase": {
+                "x-parser-schema-id": "<anonymous-schema-3>",
+                "allOf": [
+                  {
+                    "x-parser-schema-id": "<anonymous-schema-4>",
+                    "type": "string"
+                  },
+                  {
+                    "x-parser-schema-id": "<anonymous-schema-5>",
+                    "type": "string"
+                  }
+                ]
+              },
+              "object": {
+                "x-parser-schema-id": "<anonymous-schema-6>",
+                "type": "object",
+                "properties": {
+                  "prop": {
+                    "x-parser-schema-id": "<anonymous-schema-7>",
+                    "type": "string"
+                  }
+                }
+              },
+              "propWithObject": {
+                "type": "object",
+                "x-parser-schema-id": "<anonymous-schema-8>",
+                "properties": {
+                  "propWithObject": {
+                    "x-parser-schema-id": "<anonymous-schema-9>",
+                    "type": "object"
+                  }
+                }
+              }
+            },
+            "patternProperties": {
+              "patternProp": {
+                "x-parser-schema-id": "<anonymous-schema-10>",
+                "type": "string"
+              }
+            },
+            "dependencies": {
+              "dep": {
+                "x-parser-schema-id": "<anonymous-schema-11>",
+                "type": "string"
+              }
+            },
+            "definitions": {
+              "def": {
+                "x-parser-schema-id": "<anonymous-schema-12>",
+                "type": "string"
+              },
+              "oneOfCase": {
+                "x-parser-schema-id": "<anonymous-schema-13>",
+                "oneOf": [
+                  {
+                    "x-parser-schema-id": "<anonymous-schema-14>",
+                    "type": "string"
+                  },
+                  {
+                    "x-parser-schema-id": "<anonymous-schema-15>",
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "anyOf": [
+              {
+                "x-parser-schema-id": "<anonymous-schema-16>",
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "x-parser-schema-id": "<anonymous-schema-17>",
+                "properties": {
+                  "prop": {
+                    "x-parser-schema-id": "<anonymous-schema-18>",
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/processors/JsonSchemaInputProcessor.spec.ts
+++ b/test/processors/JsonSchemaInputProcessor.spec.ts
@@ -226,6 +226,6 @@ describe('JsonSchemaInputProcessor', function() {
             expect(expected.anyOf[0]['x-modelgen-inferred-name']).toEqual('anyOf_0');
             expect(expected.anyOf[1]['x-modelgen-inferred-name']).toEqual('anyOf_1');
             expect(expected.anyOf[1].properties.prop['x-modelgen-inferred-name']).toEqual('anyOf_1_prop');
-        })
+        });
     });
 });


### PR DESCRIPTION
**Description**
This PR introduces two things.
- Added unit test for reflecting schema name based on our parser.
- Fixed a bug where properties, dependencies, and definitions were never iterated. 
