### PR TITLE
chore: add unit tests to renderers

### DIFF
--- a/src/generators/typescript/TypeScriptRenderer.ts
+++ b/src/generators/typescript/TypeScriptRenderer.ts
@@ -42,8 +42,6 @@ export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOpti
     case 'integer':
     case 'number':
       return 'number';
-    case 'bigint':
-      return 'bigint';
     case 'boolean':
       return 'boolean';
     case 'array': {

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -1,6 +1,6 @@
 import { JavaGenerator } from '../../../src/generators'; 
 
-describe('TypeScriptGenerator', function() {
+describe('JavaGenerator', function() {
   let generator: JavaGenerator;
   beforeEach(() => {
     generator = new JavaGenerator();

--- a/test/generators/java/JavaRenderer.spec.ts
+++ b/test/generators/java/JavaRenderer.spec.ts
@@ -1,0 +1,58 @@
+import { JavaGenerator, JAVA_DEFAULT_PRESET } from '../../../src/generators'; 
+import { JavaRenderer } from '../../../src/generators/java/JavaRenderer';
+import { CommonInputModel, CommonModel } from '../../../src/models';
+class MockJavaRenderer extends JavaRenderer {
+
+}
+describe('JavaRenderer', function() {
+  let renderer: JavaRenderer;
+  beforeEach(() => {
+    renderer = new MockJavaRenderer({}, [], new CommonModel(), new CommonInputModel());
+  });
+
+  describe('toJavaType()', function() {
+    test('Should be able to return long', function() {
+      expect(renderer.toJavaType("long", new CommonModel())).toEqual('long');
+      expect(renderer.toJavaType("int64", new CommonModel())).toEqual('long');
+    });
+    test('Should be able to return date', function() {
+      expect(renderer.toJavaType("date", new CommonModel())).toEqual('java.time.LocalDate');
+    });
+    test('Should be able to return time', function() {
+      expect(renderer.toJavaType("time", new CommonModel())).toEqual('java.time.OffsetTime');
+    });
+    test('Should be able to return offset date time', function() {
+      expect(renderer.toJavaType("dateTime", new CommonModel())).toEqual('java.time.OffsetDateTime');
+      expect(renderer.toJavaType("date-time", new CommonModel())).toEqual('java.time.OffsetDateTime');
+    });
+    test('Should be able to return float', function() {
+      expect(renderer.toJavaType("float", new CommonModel())).toEqual('float');
+    });
+    test('Should be able to return byte array', function() {
+      expect(renderer.toJavaType("binary", new CommonModel())).toEqual('byte[]');
+    });
+  });
+
+  describe('toClassType()', function() {
+    test('Should be able to return long object', function() {
+      expect(renderer.toClassType("long")).toEqual('Long');
+    });
+    test('Should be able to return float object', function() {
+      expect(renderer.toClassType("float")).toEqual('Float');
+    });
+  });
+
+  describe('renderComments()', function() {
+    test('Should be able to render comments', function() {
+      expect(renderer.renderComments("someComment")).toEqual(`/**
+ * someComment
+ */`);
+    });
+  });
+
+  describe('renderAnnotation()', function() {
+    test('Should be able to render multiple annotations', function() {
+      expect(renderer.renderAnnotation("someComment", {"test": "test2"})).toEqual(`@SomeComment(test=test2)`);
+    });
+  });
+});

--- a/test/generators/javascript/JavaScriptRenderer.spec.ts
+++ b/test/generators/javascript/JavaScriptRenderer.spec.ts
@@ -1,0 +1,19 @@
+import { JavaScriptRenderer } from '../../../src/generators/javascript/JavaScriptRenderer';
+import { CommonInputModel, CommonModel } from '../../../src/models';
+class MockJavaScriptRenderer extends JavaScriptRenderer {
+
+}
+describe('JavaScriptRenderer', function() {
+  let renderer: JavaScriptRenderer;
+  beforeEach(() => {
+    renderer = new MockJavaScriptRenderer({}, [], new CommonModel(), new CommonInputModel());
+  });
+
+  describe('renderComments()', function() {
+    test('Should be able to render comments', function() {
+      expect(renderer.renderComments("someComment")).toEqual(`/**
+ * someComment
+ */`);
+    });
+  });
+});

--- a/test/generators/typescript/TypeScriptRenderer.spec.ts
+++ b/test/generators/typescript/TypeScriptRenderer.spec.ts
@@ -1,0 +1,38 @@
+import { TypeScriptRenderer } from '../../../src/generators/typescript/TypeScriptRenderer';
+import { CommonInputModel, CommonModel } from '../../../src/models';
+class MockTypeScriptRenderer extends TypeScriptRenderer {
+
+}
+describe('TypeScriptRenderer', function() {
+  let renderer: TypeScriptRenderer;
+  beforeEach(() => {
+    renderer = new MockTypeScriptRenderer({}, [], new CommonModel(), new CommonInputModel());
+  });
+
+  describe('renderComments()', function() {
+    test('Should be able to render comments', function() {
+      expect(renderer.renderComments("someComment")).toEqual(`/**
+ * someComment
+ */`);
+    });
+  });
+
+  describe('toTsType()', function() {
+    test('Should render any type', function() {
+      expect(renderer.toTsType(undefined, new CommonModel())).toEqual(`any`);
+    });
+    test('Should render number type', function() {
+      expect(renderer.toTsType("integer", new CommonModel())).toEqual(`number`);
+      expect(renderer.toTsType("number", new CommonModel())).toEqual(`number`);
+    });
+  });
+  describe('renderType()', function() {
+    test('Should render array of CommonModels', function() {
+      const model1 = new CommonModel();
+      model1.$ref = "ref1";
+      const model2 = new CommonModel();
+      model2.$ref = "ref2";
+      expect(renderer.renderType([model1, model2])).toEqual('ref1 | ref2');
+    });
+  });
+});


### PR DESCRIPTION
**Description**
This PR introduces the following changes:
- It removes unused switch case in TypeScript render, CommonModel type cannot be `bigint`
- Added unit tests for JavaRendere, JavaScriptRendere and TypeScriptRenderer