### PR TITLE
fix: false schemas no longer crash the library

### DIFF
--- a/src/simplification/Simplifier.ts
+++ b/src/simplification/Simplifier.ts
@@ -39,7 +39,7 @@ export class Simplifier {
       }
     }
     //If it is a false validation schema return no common model
-    if (typeof schema === 'boolean' && !schema) {
+    if (schema === false) {
       return [];
     }
     const model = new CommonModel();

--- a/src/simplification/Simplifier.ts
+++ b/src/simplification/Simplifier.ts
@@ -38,6 +38,10 @@ export class Simplifier {
         return [cachedModel];
       }
     }
+    //If it is a false validation schema return no common model
+    if (typeof schema === 'boolean' && !schema) {
+      return [];
+    }
     const model = new CommonModel();
     model.originalSchema = Schema.toSchema(schema);
     model.type = simplifyTypes(schema);

--- a/src/simplification/SimplifyTypes.ts
+++ b/src/simplification/SimplifyTypes.ts
@@ -10,10 +10,7 @@ type Output = string[] | string | undefined;
 export default function simplifyTypes(schema: Schema | boolean, seenSchemas: Map<any, Output> = new Map()): Output {
   //If we find absence of data format ensure all types are returned
   if (typeof schema === 'boolean') {
-    if (schema === true) {
-      return ['object', 'string', 'number', 'array', 'boolean', 'null', 'integer'];
-    } 
-    throw new Error('False value schemas are not supported');
+    return ['object', 'string', 'number', 'array', 'boolean', 'null', 'integer'];
   }
   const types: Output = [];
   if (seenSchemas.has(schema)) return seenSchemas.get(schema);

--- a/test/simplification/simplify.spec.ts
+++ b/test/simplification/simplify.spec.ts
@@ -9,6 +9,12 @@ import {simplify} from '../../src/simplification/Simplifier';
  * on a JSON Schema which actually makes sense but are used to test the principles.
  */
 describe('Simplification', function() {
+
+  test('should return empty models if false schema', function () {
+    const schema: any = false;
+    const models = simplify(schema);
+    expect(models).toHaveLength(0);
+  });
   test('should return as is', function() {
     const inputSchemaString = fs.readFileSync(path.resolve(__dirname, './simplify/multipleObjects.json'), 'utf8');
     const expectedSchemaString = fs.readFileSync(path.resolve(__dirname, './simplify/expected/multipleObjects.json'), 'utf8');

--- a/test/simplification/types.spec.ts
+++ b/test/simplification/types.spec.ts
@@ -46,10 +46,6 @@ describe('Simplification of types', function () {
       expect(types).toEqual(["object", "string", "number", "array", "boolean", "null",
           "integer"]);
     });
-    test('should if false return all types', function () {
-      const schema: any = false;
-      expect(() => { simplifyTypes(schema) }).toThrow("False value schemas are not supported");
-    });
   });
 
   describe('from allOf schemas', function () {


### PR DESCRIPTION
**Description**
This PR ensure false schemas are handled more gracefully.

**Related issues**
Fixes #143 