### PR TITLE
feat: simplify patternProperties

### DIFF
--- a/src/models/CommonSchema.ts
+++ b/src/models/CommonSchema.ts
@@ -7,7 +7,8 @@ export class CommonSchema<T> {
     enum?: any[];
     items?: T | T[];
     properties?: { [key: string]: T; };
-    additionalProperties?: boolean | T;
+    additionalProperties?: T;
+    patternProperties?: { [key: string]: T; };
     $ref?: string;
     required?: string[];
     
@@ -36,8 +37,16 @@ export class CommonSchema<T> {
         schema.properties = properties;
       }
       if (typeof schema.additionalProperties === 'object' && 
-            schema.additionalProperties !== null) {
+            schema.additionalProperties !== undefined) {
         schema.additionalProperties = transformationSchemaCallback(schema.additionalProperties, seenSchemas);
+      }
+      if (typeof schema.patternProperties === 'object' && 
+            schema.patternProperties !== undefined) {
+        const patternProperties : {[key: string]: T | boolean} = {};
+        Object.entries(schema.patternProperties).forEach(([pattern, patternSchema]) => {
+          patternProperties[`${pattern}`] = transformationSchemaCallback(patternSchema, seenSchemas);
+        });
+        schema.patternProperties = patternProperties;
       }
       return schema;
     }

--- a/src/models/Schema.ts
+++ b/src/models/Schema.ts
@@ -30,7 +30,6 @@ export class Schema extends CommonSchema<Schema | boolean> {
     const?: any;
     dependencies?: { [key: string]: Schema | boolean | string[]; };
     propertyNames?: Schema | boolean;
-    patternProperties?: { [key: string]: Schema | boolean; };
     if?: Schema | boolean;
     then?: Schema | boolean;
     else?: Schema | boolean;
@@ -100,14 +99,6 @@ export class Schema extends CommonSchema<Schema | boolean> {
 
       if (schema.propertyNames !== undefined) {
         schema.propertyNames = Schema.toSchema(schema.propertyNames, seenSchemas);
-      }
-
-      if (schema.patternProperties !== undefined) {
-        const patternProperties: { [key: string]: Schema | boolean } = {};
-        Object.entries(schema.patternProperties).forEach(([propertyName, property]) => {
-          patternProperties[`${propertyName}`] = Schema.toSchema(property, seenSchemas);
-        });
-        schema.patternProperties = patternProperties;
       }
       
       if (schema.if !== undefined) {

--- a/src/simplification/Simplifier.ts
+++ b/src/simplification/Simplifier.ts
@@ -7,6 +7,7 @@ import simplifyRequired from './SimplifyRequired';
 import simplifyTypes from './SimplifyTypes';
 import { SimplificationOptions } from '../models/SimplificationOptions';
 import simplifyAdditionalProperties from './SimplifyAdditionalProperties';
+import simplifyPatternProperties from './SimplifyPatternProperties';
 import { isModelObject } from './Utils';
 import simplifyName from './SimplifyName';
 
@@ -80,6 +81,11 @@ export class Simplifier {
     const simplifiedProperties = simplifyProperties(schema, this);
     if (simplifiedProperties !== undefined) {
       model.properties = simplifiedProperties;
+    }
+
+    const simplifiedPatternProperties = simplifyPatternProperties(schema, this);
+    if (simplifiedPatternProperties !== undefined) {
+      model.patternProperties = simplifiedPatternProperties;
     }
 
     const simplifiedAdditionalProperties = simplifyAdditionalProperties(schema, this, model);

--- a/src/simplification/Simplifier.ts
+++ b/src/simplification/Simplifier.ts
@@ -144,7 +144,7 @@ export class Simplifier {
     }
     if (model.additionalProperties) {
       const existingAdditionalProperties = model.additionalProperties;
-      model.additionalProperties = this.splitModels(existingAdditionalProperties as CommonModel);
+      model.additionalProperties = this.splitModels(existingAdditionalProperties);
     }
   }
 }

--- a/src/simplification/Simplifier.ts
+++ b/src/simplification/Simplifier.ts
@@ -146,6 +146,12 @@ export class Simplifier {
       const existingAdditionalProperties = model.additionalProperties;
       model.additionalProperties = this.splitModels(existingAdditionalProperties);
     }
+    if (model.patternProperties) {
+      const existingPatternProperties = model.patternProperties;
+      for (const [pattern, patternModel] of Object.entries(existingPatternProperties)) {
+        model.patternProperties[`${pattern}`] = this.splitModels(patternModel);
+      }
+    }
   }
 }
 

--- a/src/simplification/SimplifyAdditionalProperties.ts
+++ b/src/simplification/SimplifyAdditionalProperties.ts
@@ -5,7 +5,7 @@ import { isModelObject } from './Utils';
 type Output = CommonModel | undefined;
 
 /**
- * Find out which common models we should extend
+ * Simplifier function for finding the simplified version of additional properties
  * 
  * @param schema to find extends of
  */

--- a/src/simplification/SimplifyPatternProperties.ts
+++ b/src/simplification/SimplifyPatternProperties.ts
@@ -33,7 +33,7 @@ export default function simplifyPatternProperties(schema: Schema | boolean, simp
     combineSchemas(schema.then, output, simplifier, seenSchemas, schema);
     combineSchemas(schema.else, output, simplifier, seenSchemas, schema);
 
-    return !Object.keys(output).length ? undefined : output;
+    return Object.keys(output).length ? output : undefined;
   }
   return undefined;
 }

--- a/src/simplification/SimplifyProperties.ts
+++ b/src/simplification/SimplifyProperties.ts
@@ -36,7 +36,7 @@ export default function simplifyProperties(schema: Schema | boolean, simplifier 
     combineSchemas(schema.then, output, simplifier, seenSchemas, schema);
     combineSchemas(schema.else, output, simplifier, seenSchemas, schema);
 
-    return !Object.keys(output).length ? undefined : output;
+    return Object.keys(output).length ? output : undefined;
   }
   return undefined;
 }

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -97,13 +97,6 @@ describe('CommonModel', function() {
       const d = CommonModel.toCommonModel(doc);
       expect(d.additionalProperties).toEqual(undefined);
     });
-    
-    test('should return undefined when null', function() {
-      const doc: any = { additionalProperties: null };
-      const d = CommonModel.toCommonModel(doc);
-      expect(d.additionalProperties).not.toBeUndefined();
-      expect(d.additionalProperties).toEqual(doc.additionalProperties);
-    });
   });
 
   describe('$ref', function() {
@@ -371,8 +364,69 @@ describe('CommonModel', function() {
         expect(doc1.properties).toBeUndefined();
       });
     });
-  });
+    describe('additionalProperties', function() {
+      test('should be merged when only right side is defined', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc2.additionalProperties = CommonModel.toCommonModel({type: "string"});
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.additionalProperties).toEqual(doc2.additionalProperties);
+      });
+      test('should be merged together when both sides are defined', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc2.additionalProperties = CommonModel.toCommonModel({type: "string"});
+        doc1.additionalProperties = CommonModel.toCommonModel({type: "number"});
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.additionalProperties).toEqual({type: ["number", "string"], originalSchema: {}});
+      });
+      test('should not change if nothing is defined', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.patternProperties).toBeUndefined();
+      });
+    });
 
+    describe('patternProperties', function() {
+      test('should be merged when only right side is defined', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc2.patternProperties = {"pattern1": CommonModel.toCommonModel({type: "string"})};
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.patternProperties).toEqual(doc2.patternProperties);
+      });
+      test('should be merged when both sides are defined', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc2.patternProperties = {"pattern1": CommonModel.toCommonModel({type: "string"})};
+        doc1.patternProperties = {"pattern2": CommonModel.toCommonModel({type: "number"})};
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.patternProperties).toEqual({"pattern1": {type: "string"}, "pattern2": {type: "number"}});
+      });
+      test('should be merged together when both sides are defined', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc2.patternProperties = {"pattern1": CommonModel.toCommonModel({type: "string"})};
+        doc1.patternProperties = {"pattern1": CommonModel.toCommonModel({type: "number"})};
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.patternProperties).toEqual({"pattern1": {type: ["number", "string"], originalSchema: {}}});
+      });
+      test('should not change if nothing is defined', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.patternProperties).toBeUndefined();
+      });
+    });
+  });
   describe('helpers', function() {
     describe('getFromSchema', function() {
       test('should work', function() {

--- a/test/models/Schema.spec.ts
+++ b/test/models/Schema.spec.ts
@@ -313,13 +313,6 @@ describe('Schema', function() {
       expect(typeof d).toEqual("object");
       expect(d.additionalProperties).toEqual(undefined);
     });
-    
-    test('should return undefined when null', function() {
-      const doc: any = { additionalProperties: null };
-      const d = Schema.toSchema(doc) as Schema;
-      expect(typeof d).toEqual("object");
-      expect(d.additionalProperties).toEqual(null);
-    });
   });
 
   describe('additionalItems', function() {

--- a/test/simplification/patternProperties.spec.ts
+++ b/test/simplification/patternProperties.spec.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import { CommonModel } from '../../src/models';
 import { SimplificationOptions } from '../../src/models/SimplificationOptions';
 import { Simplifier } from '../../src/simplification/Simplifier';
-import simplifyProperties from '../../src/simplification/SimplifyProperties';
+import simplifyPatternProperties from '../../src/simplification/SimplifyPatternProperties';
 jest.mock('../../src/simplification/Simplifier', () => {
   return {
     Simplifier: jest.fn().mockImplementation(() => {
@@ -29,8 +29,8 @@ const expectFunction = (inputSchemaPath: string, expectedPropertiesPath: string,
   const inputSchema = JSON.parse(inputSchemaString);
   const expectedProperties = JSON.parse(expectedCommonInputModelString);
   const simplifier = new Simplifier(options);
-  const properties = simplifyProperties(inputSchema, simplifier);
-  expect(properties).toEqual(expectedProperties);
+  const patternProperties = simplifyPatternProperties(inputSchema, simplifier);
+  expect(patternProperties).toEqual(expectedProperties);
   return simplifier;
 };
 
@@ -38,85 +38,85 @@ const expectFunction = (inputSchemaPath: string, expectedPropertiesPath: string,
  * Some of these test are purely theoretical and have little if any merit 
  * on a JSON Schema which actually makes sense, but they are used to test the principles.
  */
-describe('Simplification of properties', () => {
+describe('Simplification of patternProperties', () => {
   afterAll(() => {
     jest.restoreAllMocks();
   })
   test('should return as is', () => {
-    const inputSchemaPath = './properties/basic.json';
-    const expectedPropertiesPath = './properties/expected/basic.json';
+    const inputSchemaPath = './patternProperties/basic.json';
+    const expectedPropertiesPath = './patternProperties/expected/basic.json';
     const simplifier = expectFunction(inputSchemaPath, expectedPropertiesPath);
     expect(simplifier.simplify).toHaveBeenCalledTimes(2);
   });
   
   describe('if inheritance turned off allOf schemas should be merged', () => {
     test('when simple schema', () => {
-      const inputSchemaPath = './properties/allOf.json';
-      const expectedPropertiesPath = './properties/expected/allOf.json';
+      const inputSchemaPath = './patternProperties/allOf.json';
+      const expectedPropertiesPath = './patternProperties/expected/allOf.json';
       const simplifier = expectFunction(inputSchemaPath, expectedPropertiesPath, {allowInheritance: false});
       expect(simplifier.simplify).toHaveBeenCalledTimes(2);
     });
     test('when nested schema', () => {
-      const inputSchemaPath = './properties/allOfNested.json';
-      const expectedPropertiesPath = './properties/expected/allOfNested.json';
+      const inputSchemaPath = './patternProperties/allOfNested.json';
+      const expectedPropertiesPath = './patternProperties/expected/allOfNested.json';
       const simplifier = expectFunction(inputSchemaPath, expectedPropertiesPath, {allowInheritance: false});
       expect(simplifier.simplify).toHaveBeenCalledTimes(3);
     });
   });
   describe('from anyOf schemas', () => {
     test('with simple schema', () => {
-      const inputSchemaPath = './properties/anyOf.json';
-      const expectedPropertiesPath = './properties/expected/anyOf.json';
+      const inputSchemaPath = './patternProperties/anyOf.json';
+      const expectedPropertiesPath = './patternProperties/expected/anyOf.json';
       const simplifier = expectFunction(inputSchemaPath, expectedPropertiesPath);
       expect(simplifier.simplify).toHaveBeenCalledTimes(2);
     });
     test('with nested schema', () => {
-      const inputSchemaPath = './properties/anyOfNested.json';
-      const expectedPropertiesPath = './properties/expected/anyOfNested.json';
+      const inputSchemaPath = './patternProperties/anyOfNested.json';
+      const expectedPropertiesPath = './patternProperties/expected/anyOfNested.json';
       const simplifier = expectFunction(inputSchemaPath, expectedPropertiesPath);
       expect(simplifier.simplify).toHaveBeenCalledTimes(3);
     });
   });
   describe('from oneOf schemas', () => {
     test('with simple schema', () => {
-      const inputSchemaPath = './properties/oneOf.json';
-      const expectedPropertiesPath = './properties/expected/oneOf.json';
+      const inputSchemaPath = './patternProperties/oneOf.json';
+      const expectedPropertiesPath = './patternProperties/expected/oneOf.json';
       const simplifier = expectFunction(inputSchemaPath, expectedPropertiesPath);
       expect(simplifier.simplify).toHaveBeenCalledTimes(2);
     });
     test('with nested oneOf schemas', () => {
-      const inputSchemaPath = './properties/oneOfNested.json';
-      const expectedPropertiesPath = './properties/expected/oneOfNested.json';
+      const inputSchemaPath = './patternProperties/oneOfNested.json';
+      const expectedPropertiesPath = './patternProperties/expected/oneOfNested.json';
       const simplifier = expectFunction(inputSchemaPath, expectedPropertiesPath);
       expect(simplifier.simplify).toHaveBeenCalledTimes(3);
     });
   });
   describe('from if/then/else schemas', () => {
     test('with simple schema', () => {
-      const inputSchemaPath = './properties/conditional.json';
-      const expectedPropertiesPath = './properties/expected/conditional.json';
+      const inputSchemaPath = './patternProperties/conditional.json';
+      const expectedPropertiesPath = './patternProperties/expected/conditional.json';
       const simplifier = expectFunction(inputSchemaPath, expectedPropertiesPath);
       expect(simplifier.simplify).toHaveBeenCalledTimes(3);
     });
     test('with nested schema', () => {
-      const inputSchemaPath = './properties/conditionalNested.json';
-      const expectedPropertiesPath = './properties/expected/conditionalNested.json';
+      const inputSchemaPath = './patternProperties/conditionalNested.json';
+      const expectedPropertiesPath = './patternProperties/expected/conditionalNested.json';
       const simplifier = expectFunction(inputSchemaPath, expectedPropertiesPath);
       expect(simplifier.simplify).toHaveBeenCalledTimes(5);
     });
   });
-  test('Should merge properties which same key', () => {
-    const inputSchemaPath = './properties/combine_properties.json';
+  test('Should merge patternProperties which same key', () => {
+    const inputSchemaPath = './patternProperties/combinePatternProperties.json';
     const mockMergeCommonModels = jest.fn().mockReturnValue(new CommonModel());
     CommonModel.mergeCommonModels = mockMergeCommonModels;
-    const expectedPropertiesPath = './properties/expected/combine_properties.json';
+    const expectedPropertiesPath = './patternProperties/expected/combinePatternProperties.json';
     const simplifier = expectFunction(inputSchemaPath, expectedPropertiesPath);
     expect(simplifier.simplify).toHaveBeenCalledTimes(2);
     expect(mockMergeCommonModels).toHaveBeenCalledTimes(1);
   });
   test('Should split out multiple objects into their own models and add reference', () => {
-    const inputSchemaPath = './properties/multiple_objects.json';
-    const expectedPropertiesPath = './properties/expected/multiple_objects.json';
+    const inputSchemaPath = './patternProperties/multipleObjects.json';
+    const expectedPropertiesPath = './patternProperties/expected/multipleObjects.json';
     const simplifier = expectFunction(inputSchemaPath, expectedPropertiesPath);
     expect(simplifier.simplify).toHaveBeenCalledTimes(2);
   });
@@ -127,7 +127,7 @@ describe('Simplification of properties', () => {
     model.$id = "test2";
     alreadySeen.set(schema, {"testProp": model});
     const simplifier = new Simplifier();
-    const output = simplifyProperties(schema, simplifier, alreadySeen);
+    const output = simplifyPatternProperties(schema, simplifier, alreadySeen);
     expect(output).toEqual({"testProp": model});
   });
 });

--- a/test/simplification/patternProperties/allOf.json
+++ b/test/simplification/patternProperties/allOf.json
@@ -1,0 +1,18 @@
+{
+  "allOf": [
+    {
+      "patternProperties": {
+        "testPattern1": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "patternProperties": {
+        "testPattern2": {
+          "type": "string"
+        }
+      }
+    }
+  ]
+}

--- a/test/simplification/patternProperties/allOfNested.json
+++ b/test/simplification/patternProperties/allOfNested.json
@@ -1,0 +1,29 @@
+{
+  "allOf": [
+      {
+          "allOf": [
+              { 
+                "patternProperties": { 
+                  "testPattern1": { 
+                    "type": "string"
+                  } 
+                }  
+              },
+              { 
+                "patternProperties": { 
+                  "testPattern2": { 
+                    "type": "string"
+                  } 
+                }  
+              }
+          ]
+      },
+      { 
+        "patternProperties": { 
+          "testPattern3": { 
+            "type": "string"
+          } 
+        }
+      }
+  ]
+}

--- a/test/simplification/patternProperties/anyOf.json
+++ b/test/simplification/patternProperties/anyOf.json
@@ -1,0 +1,18 @@
+{
+  "anyOf": [
+    { 
+      "patternProperties": { 
+        "testPattern1": { 
+          "type": "string"
+        } 
+      }  
+    },
+    { 
+      "patternProperties": { 
+        "testPattern2": { 
+          "type": "string"
+        } 
+      }
+    }
+  ]
+}

--- a/test/simplification/patternProperties/anyOfNested.json
+++ b/test/simplification/patternProperties/anyOfNested.json
@@ -1,0 +1,29 @@
+{
+    "anyOf": [
+        {
+            "anyOf": [
+                { 
+                  "patternProperties": { 
+                    "testPattern1": { 
+                      "type": "string"
+                    } 
+                  }  
+                },
+                { 
+                  "patternProperties": { 
+                    "testPattern2": { 
+                      "type": "string"
+                    } 
+                  }  
+                }
+            ]
+        },
+        { 
+          "patternProperties": { 
+            "testPattern3": { 
+              "type": "string"
+            } 
+          }
+        }
+    ]
+}

--- a/test/simplification/patternProperties/basic.json
+++ b/test/simplification/patternProperties/basic.json
@@ -1,0 +1,10 @@
+{
+  "patternProperties": { 
+    "testPattern1": { 
+      "type": "string"
+    },
+    "testPattern2": { 
+      "type": "string"
+    } 
+  }
+}

--- a/test/simplification/patternProperties/combinePatternProperties.json
+++ b/test/simplification/patternProperties/combinePatternProperties.json
@@ -1,0 +1,24 @@
+{
+  "anyOf":[
+    {
+      "patternProperties":{
+        "testPattern1":{
+          "type":"string",
+          "enum":[
+            "merge"
+          ]
+        }
+      }
+    },
+    {
+      "patternProperties":{
+        "testPattern1":{
+          "type":"number",
+          "enum":[
+            0
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/simplification/patternProperties/conditional.json
+++ b/test/simplification/patternProperties/conditional.json
@@ -1,0 +1,28 @@
+{
+    "patternProperties": { 
+      "testPattern1": { 
+        "type": "string"
+      } 
+    },
+    "if": {
+        "patternProperties": { 
+          "testPattern1": { 
+            "const": "string"
+          } 
+        } 
+    },
+    "then": {
+        "patternProperties": { 
+          "testPattern2": { 
+            "type": "string"
+          } 
+        } 
+    },
+    "else": {
+        "patternProperties": { 
+          "testPattern3": { 
+            "type": "string"
+          } 
+        } 
+    }
+}

--- a/test/simplification/patternProperties/conditionalNested.json
+++ b/test/simplification/patternProperties/conditionalNested.json
@@ -1,0 +1,49 @@
+{
+    "patternProperties": { 
+      "testPattern1": { 
+        "type": "string"
+      }
+    },
+    "if": {
+        "patternProperties": { 
+          "testPattern1": { 
+            "const": "string"
+          } 
+        } 
+    },
+    "then": {
+        "patternProperties": {
+          "testPattern2": { 
+            "type": "string"
+          } 
+        },
+        "if": {
+            "patternProperties": { 
+              "testPattern2": { 
+                "const": "string"
+              } 
+            } 
+        },
+        "then": {
+            "patternProperties": { 
+              "testPattern3": { 
+                "type": "string"
+              } 
+            } 
+        },
+        "else": {
+            "patternProperties": { 
+              "testPattern4": { 
+                "type": "string"
+              } 
+            } 
+        }
+    },
+    "else": {
+        "patternProperties": { 
+          "testPattern5": { 
+            "type": "string"
+          } 
+        } 
+    }
+}

--- a/test/simplification/patternProperties/expected/allOf.json
+++ b/test/simplification/patternProperties/expected/allOf.json
@@ -1,0 +1,4 @@
+{
+  "testPattern1":{  },
+  "testPattern2":{  }
+}

--- a/test/simplification/patternProperties/expected/allOfNested.json
+++ b/test/simplification/patternProperties/expected/allOfNested.json
@@ -1,0 +1,5 @@
+{
+  "testPattern1": {  },
+  "testPattern2": {  },
+  "testPattern3": {  }
+}

--- a/test/simplification/patternProperties/expected/anyOf.json
+++ b/test/simplification/patternProperties/expected/anyOf.json
@@ -1,0 +1,4 @@
+{
+  "testPattern1": {  },
+  "testPattern2": {  }
+}

--- a/test/simplification/patternProperties/expected/anyOfNested.json
+++ b/test/simplification/patternProperties/expected/anyOfNested.json
@@ -1,0 +1,5 @@
+{
+  "testPattern1": {  },
+  "testPattern2": {  },
+  "testPattern3": {  }
+}

--- a/test/simplification/patternProperties/expected/basic.json
+++ b/test/simplification/patternProperties/expected/basic.json
@@ -1,0 +1,4 @@
+{
+  "testPattern1": { },
+  "testPattern2": { }
+}

--- a/test/simplification/patternProperties/expected/combinePatternProperties.json
+++ b/test/simplification/patternProperties/expected/combinePatternProperties.json
@@ -1,0 +1,3 @@
+{
+  "testPattern1": { }
+}

--- a/test/simplification/patternProperties/expected/conditional.json
+++ b/test/simplification/patternProperties/expected/conditional.json
@@ -1,0 +1,5 @@
+{
+  "testPattern1": {  },
+  "testPattern2": {  },
+  "testPattern3": {  }
+}

--- a/test/simplification/patternProperties/expected/conditionalNested.json
+++ b/test/simplification/patternProperties/expected/conditionalNested.json
@@ -1,0 +1,7 @@
+{
+  "testPattern1": {  },
+  "testPattern2": {  },
+  "testPattern3": {  },
+  "testPattern4": {  },
+  "testPattern5": {  }
+}

--- a/test/simplification/patternProperties/expected/multipleObjects.json
+++ b/test/simplification/patternProperties/expected/multipleObjects.json
@@ -1,0 +1,4 @@
+{
+  "street_address":{ },
+  "country": { }
+}

--- a/test/simplification/patternProperties/expected/oneOf.json
+++ b/test/simplification/patternProperties/expected/oneOf.json
@@ -1,0 +1,4 @@
+{
+  "testPattern1": { },
+  "testPattern2": { }
+}

--- a/test/simplification/patternProperties/expected/oneOfNested.json
+++ b/test/simplification/patternProperties/expected/oneOfNested.json
@@ -1,0 +1,5 @@
+{
+  "testPattern1": { },
+  "testPattern2": { },
+  "testPattern3": { }
+}

--- a/test/simplification/patternProperties/multipleObjects.json
+++ b/test/simplification/patternProperties/multipleObjects.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "patternProperties": {
+    "street_address": {
+      "type": "object",
+      "patternProperties": {
+        "floor": {
+          "type": "number"
+        }
+      }
+    },
+    "country": {
+      "enum": ["United States of America", "Canada"]
+    }
+  }
+}

--- a/test/simplification/patternProperties/oneOf.json
+++ b/test/simplification/patternProperties/oneOf.json
@@ -1,0 +1,18 @@
+{
+  "oneOf": [
+    { 
+      "patternProperties": { 
+        "testPattern1": { 
+          "type": "string"
+        } 
+      }  
+    },
+    { 
+      "patternProperties": { 
+        "testPattern2": { 
+          "type": "string"
+        } 
+      }
+    }
+  ]
+}

--- a/test/simplification/patternProperties/oneOfNested.json
+++ b/test/simplification/patternProperties/oneOfNested.json
@@ -1,0 +1,29 @@
+{
+    "oneOf": [
+        {
+            "oneOf": [
+                { 
+                  "patternProperties": { 
+                    "testPattern1": { 
+                      "type": "string"
+                    } 
+                  }  
+                },
+                { 
+                  "patternProperties": { 
+                    "testPattern2": { 
+                      "type": "string"
+                    } 
+                  }  
+                }
+            ]
+        },
+        { 
+          "patternProperties": { 
+            "testPattern3": { 
+              "type": "string"
+            } 
+          }
+        }
+    ]
+}


### PR DESCRIPTION
**Description**
This PR moves the patternProperties property from Schema to CommonModel to allow rendering of pattern properties.

Beside this main feature:
- Fixed unnecessary ignore of lint rule.
- Added better docs
- Added missing tests for additionalProperties merge 

**Related issue(s)**
Solves #43 