### PR TITLE
fix: ensure that required list of properties are merged

### DIFF
--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -133,11 +133,10 @@ export class CommonModel extends CommonSchema<CommonModel> {
     CommonModel.mergeTypes(mergeTo, mergeFrom);
 
     if (mergeFrom.enum !== undefined) {
-      if (mergeTo.enum === undefined) {
-        mergeTo.enum = mergeFrom.enum;
-      } else {
-        mergeTo.enum = [...mergeTo.enum, ...mergeFrom.enum];
-      }
+      mergeTo.enum = [... new Set([...(mergeTo.enum || []), ...mergeFrom.enum])];
+    }
+    if (mergeFrom.required !== undefined) {
+      mergeTo.required = [... new Set([...(mergeTo.required || []), ...mergeFrom.required])];
     }
 
     // Which values are correct to use here? Is allOf required?

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -310,6 +310,15 @@ describe('CommonModel', function() {
         doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
         expect(doc1.enum).toEqual(doc2.enum);
       });
+      test('Should not contain duplicate values', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc2.enum = ["string"];
+        doc1.enum = ["string"];
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.enum).toEqual(["string"]);
+      });
       test('should be merged when both sides are defined', function() {
         const doc: Schema = { };
         let doc1 = CommonModel.toCommonModel(doc);

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -180,6 +180,49 @@ describe('CommonModel', function() {
         expect(doc1.$id).toBeUndefined();
       });
     });
+    describe('required', function() {
+      test('should contain the same if right side is not defined', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc1.required = ["test"];
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.required).toEqual(["test"]);
+      });
+      test('should be merged when only right side is defined', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc2.required = ["test"];
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.required).toEqual(doc2.required);
+      });
+      test('should be merged when both sides are defined', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc1.required = ["test"];
+        doc2.required = ["test2"];
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.required).toEqual(["test", "test2"]);
+      });
+      test('should only contain one if duplicate', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc1.required = ["test"];
+        doc2.required = ["test"];
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.required).toEqual(["test"]);
+      });
+      test('should not change if nothing is defined', function() {
+        const doc: Schema = { };
+        let doc1 = CommonModel.toCommonModel(doc);
+        let doc2 = CommonModel.toCommonModel(doc);
+        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+        expect(doc1.required).toBeUndefined();
+      });
+    });
     describe('$ref', function() {
       test('should be merged when only right side is defined', function() {
         const doc: Schema = { };


### PR DESCRIPTION
**Description**
This PR fixes a problem where the required list of properties is not merged between CommonModels.

Furthermore, this removes duplicate enum values.

**Related issue(s)**
fixes #158 