### PR TITLE
fix: referenced models should render their type as pascal case

### DIFF
--- a/src/generators/java/JavaRenderer.ts
+++ b/src/generators/java/JavaRenderer.ts
@@ -24,7 +24,7 @@ export abstract class JavaRenderer extends AbstractRenderer<JavaOptions> {
       return 'Object'; // fallback
     }
     if (model.$ref !== undefined) {
-      return model.$ref;
+      return FormatHelpers.toPascalCase(model.$ref);
     }
     const format = model.getFromSchema('format');
     return this.toClassType(this.toJavaType(format || model.type, model));

--- a/src/generators/typescript/TypeScriptRenderer.ts
+++ b/src/generators/typescript/TypeScriptRenderer.ts
@@ -27,7 +27,7 @@ export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOpti
       return model.enum.map(value => typeof value === 'string' ? `"${value}"` : value).join(' | ');
     }
     if (model.$ref !== undefined) {
-      return model.$ref;
+      return FormatHelpers.toPascalCase(model.$ref);
     }
     if (Array.isArray(model.type)) {
       return model.type.map(t => this.toTsType(t, model)).join(' | ');

--- a/test/generators/java/JavaRenderer.spec.ts
+++ b/test/generators/java/JavaRenderer.spec.ts
@@ -10,7 +10,20 @@ describe('JavaRenderer', function() {
     renderer = new MockJavaRenderer({}, [], new CommonModel(), new CommonInputModel());
   });
 
+  describe('renderType()', function() {
+    test('Should render refs with pascal case', function() {
+      const model = new CommonModel();
+      model.$ref = "<anonymous-schema-1>";
+      expect(renderer.renderType(model)).toEqual('AnonymousSchema_1');
+    });
+  });
+
   describe('toJavaType()', function() {
+    test('Should render refs with pascal case', function() {
+      const model = new CommonModel();
+      model.$ref = "<anonymous-schema-1>";
+      expect(renderer.renderType(model)).toEqual('AnonymousSchema_1');
+    });
     test('Should be able to return long', function() {
       expect(renderer.toJavaType("long", new CommonModel())).toEqual('long');
       expect(renderer.toJavaType("int64", new CommonModel())).toEqual('long');

--- a/test/generators/java/JavaRenderer.spec.ts
+++ b/test/generators/java/JavaRenderer.spec.ts
@@ -19,11 +19,6 @@ describe('JavaRenderer', function() {
   });
 
   describe('toJavaType()', function() {
-    test('Should render refs with pascal case', function() {
-      const model = new CommonModel();
-      model.$ref = "<anonymous-schema-1>";
-      expect(renderer.renderType(model)).toEqual('AnonymousSchema_1');
-    });
     test('Should be able to return long', function() {
       expect(renderer.toJavaType("long", new CommonModel())).toEqual('long');
       expect(renderer.toJavaType("int64", new CommonModel())).toEqual('long');

--- a/test/generators/typescript/TypeScriptRenderer.spec.ts
+++ b/test/generators/typescript/TypeScriptRenderer.spec.ts
@@ -27,12 +27,17 @@ describe('TypeScriptRenderer', function() {
     });
   });
   describe('renderType()', function() {
+    test('Should render refs with pascal case', function() {
+      const model = new CommonModel();
+      model.$ref = "<anonymous-schema-1>";
+      expect(renderer.renderType(model)).toEqual('AnonymousSchema_1');
+    });
     test('Should render array of CommonModels', function() {
       const model1 = new CommonModel();
       model1.$ref = "ref1";
       const model2 = new CommonModel();
       model2.$ref = "ref2";
-      expect(renderer.renderType([model1, model2])).toEqual('ref1 | ref2');
+      expect(renderer.renderType([model1, model2])).toEqual('Ref1 | Ref2');
     });
     test('Should render enums', function() {
       const model = new CommonModel();


### PR DESCRIPTION
**Description**
This PR fixes a naming issue between referenced models when being rendered as properties.

**Related issue(s)**
fixes #168 