### PR TITLE
refactor: add support functions for CommonModel

### DIFF
--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -133,9 +133,11 @@ export class CommonModel extends CommonSchema<CommonModel> {
   }
   /**
    * Merge two common model properties together 
+   * 
    * @param mergeTo 
    * @param mergeFrom 
    * @param originalSchema 
+   * @param alreadyIteratedModels 
    */
   private static mergeProperties(mergeTo: CommonModel, mergeFrom: CommonModel, originalSchema: Schema, alreadyIteratedModels: Map<CommonModel, CommonModel> = new Map()) {
     const mergeToProperties = mergeTo.properties;

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -28,7 +28,7 @@ export class CommonModel extends CommonSchema<CommonModel> {
    */
   getFromSchema<K extends keyof Schema>(key: K) {
     let schema = this.originalSchema || {};
-    if (typeof schema === 'boolean') schema = {};
+    if (typeof schema === 'boolean') return undefined;
     return schema[`${key}`];
   }
 

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -134,10 +134,10 @@ export class CommonModel extends CommonSchema<CommonModel> {
   /**
    * Merge two common model properties together 
    * 
-   * @param mergeTo 
-   * @param mergeFrom 
-   * @param originalSchema 
-   * @param alreadyIteratedModels 
+   * @param mergeTo CommonModel to merge properties into
+   * @param mergeFrom CommonModel to merge properties from
+   * @param originalSchema schema to use as original schema
+   * @param alreadyIteratedModels to handle circular models correctly
    */
   private static mergeProperties(mergeTo: CommonModel, mergeFrom: CommonModel, originalSchema: Schema, alreadyIteratedModels: Map<CommonModel, CommonModel> = new Map()) {
     const mergeToProperties = mergeTo.properties;
@@ -158,9 +158,11 @@ export class CommonModel extends CommonSchema<CommonModel> {
   }
   /**
    * Merge two common model additional properties together 
-   * @param mergeTo 
-   * @param mergeFrom 
-   * @param originalSchema 
+   * 
+   * @param mergeTo CommonModel to merge additional properties into
+   * @param mergeFrom CommonModel to merge additional properties from
+   * @param originalSchema schema to use as original schema
+   * @param alreadyIteratedModels to handle circular models correctly
    */
   private static mergeAdditionalProperties(mergeTo: CommonModel, mergeFrom: CommonModel, originalSchema: Schema, alreadyIteratedModels: Map<CommonModel, CommonModel> = new Map()) {
     const mergeToAdditionalProperties = mergeTo.additionalProperties;
@@ -175,9 +177,11 @@ export class CommonModel extends CommonSchema<CommonModel> {
   }
   /**
    * Merge two common model pattern properties together 
-   * @param mergeTo 
-   * @param mergeFrom 
-   * @param originalSchema 
+   * 
+   * @param mergeTo CommonModel to merge pattern properties into
+   * @param mergeFrom CommonModel to merge pattern properties from
+   * @param originalSchema schema to use as original schema
+   * @param alreadyIteratedModels to handle circular models correctly
    */
   private static mergePatternProperties(mergeTo: CommonModel, mergeFrom: CommonModel, originalSchema: Schema, alreadyIteratedModels: Map<CommonModel, CommonModel> = new Map()) {
     const mergeToPatternProperties = mergeTo.patternProperties;
@@ -200,9 +204,10 @@ export class CommonModel extends CommonSchema<CommonModel> {
   /**
    * Merge items together so only one CommonModel remains.
    * 
-   * @param mergeTo CommonModel to merge types into
-   * @param mergeFrom CommonModel to merge from
-   * @param originalSchema 
+   * @param mergeTo CommonModel to merge items into
+   * @param mergeFrom CommonModel to merge items from
+   * @param originalSchema schema to use as original schema
+   * @param alreadyIteratedModels to handle circular models correctly
    */
   private static mergeItems(mergeTo: CommonModel, mergeFrom: CommonModel, originalSchema: Schema, alreadyIteratedModels: Map<CommonModel, CommonModel> = new Map()) {
     const merge = (models: CommonModel | CommonModel[] | undefined): CommonModel | undefined => {
@@ -270,6 +275,7 @@ export class CommonModel extends CommonSchema<CommonModel> {
    * @param mergeTo CommonModel to merge into
    * @param mergeFrom CommonModel to merge values from
    * @param originalSchema schema to use as original schema
+   * @param alreadyIteratedModels to handle circular models correctly
    */
   static mergeCommonModels(mergeTo: CommonModel | undefined, mergeFrom: CommonModel, originalSchema: Schema, alreadyIteratedModels: Map<CommonModel, CommonModel> = new Map()): CommonModel {
     if (mergeTo === undefined) return mergeFrom;

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -27,7 +27,7 @@ export class CommonModel extends CommonSchema<CommonModel> {
    * @returns {any}
    */
   getFromSchema<K extends keyof Schema>(key: K) {
-    let schema = this.originalSchema || {};
+    const schema = this.originalSchema || {};
     if (typeof schema === 'boolean') return undefined;
     return schema[`${key}`];
   }
@@ -294,17 +294,10 @@ export class CommonModel extends CommonSchema<CommonModel> {
     if (mergeFrom.required !== undefined) {
       mergeTo.required = [... new Set([...(mergeTo.required || []), ...mergeFrom.required])];
     }
-
     // Which values are correct to use here? Is allOf required?
-    if (mergeFrom.$id !== undefined && mergeTo.$id === undefined) {
-      mergeTo.$id = mergeFrom.$id;
-    }
-    if (mergeFrom.$ref !== undefined && mergeTo.$ref === undefined) {
-      mergeTo.$ref = mergeFrom.$ref;
-    }
-    if (mergeFrom.extend !== undefined && mergeTo.extend === undefined) {
-      mergeTo.extend = mergeFrom.extend;
-    }
+    mergeTo.$id = mergeTo.$id || mergeFrom.$id;
+    mergeTo.$ref = mergeTo.$ref || mergeFrom.$ref;
+    mergeTo.extend = mergeTo.extend || mergeFrom.extend;
     mergeTo.originalSchema = originalSchema;
     return mergeTo;
   }

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -493,6 +493,41 @@ describe('CommonModel', function() {
     });
   });
 
+  describe('setTypes', function() {
+    test('should set multiple types', function() {
+      const model = new CommonModel(); 
+      model.setType(['type1', 'type2']);
+      expect(model.type).toEqual(['type1', 'type2']);
+    });
+    test('should set array type as regular type with length 1', function() {
+      const model = new CommonModel(); 
+      model.setType(['type']);
+      expect(model.type).toEqual('type');
+    });
+    test('should set type undefined with array of length 0', function() {
+      const model = new CommonModel(); 
+      model.setType([]);
+      expect(model.type).toBeUndefined();
+    });
+    test('should set type as is', function() {
+      const model = new CommonModel(); 
+      model.setType('type');
+      expect(model.type).toEqual('type');
+    });
+    test('should set type overwriting existing type', function() {
+      const model = new CommonModel(); 
+      model.type = ['type1'];
+      model.setType('type2');
+      expect(model.type).toEqual('type2');
+    });
+    test('should overwrite already sat type', function() {
+      const model = new CommonModel(); 
+      model.setType('type1');
+      model.setType('type2');
+      expect(model.type).toEqual('type2');
+    });
+  });
+
   describe('addToTypes', function() {
     test('should add multiple types', function() {
       const model = new CommonModel(); 

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -147,6 +147,18 @@ describe('CommonModel', function() {
     });
   });
   describe('mergeCommonModels', function() {
+    test('should handle recursive models', function() {
+      const doc: Schema = { };
+      let doc1 = CommonModel.toCommonModel(doc);
+      doc1.properties = {
+        "recursive": doc1
+      }
+      let doc2 = CommonModel.toCommonModel(doc);
+      doc2.properties = {
+        "recursive": doc2
+      }
+      doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
+    });
     describe('$id', function() {
       test('should be merged when only right side is defined', function() {
         const doc: Schema = { };
@@ -156,14 +168,15 @@ describe('CommonModel', function() {
         doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
         expect(doc1.$id).toEqual(doc2.$id);
       });
-      test('should be merged when both sides are defined', function() {
+      test('should not be merged when both sides are defined', function() {
         const doc: Schema = { };
         let doc1 = CommonModel.toCommonModel(doc);
         let doc2 = CommonModel.toCommonModel(doc);
         doc2.$id = "test";
         doc1.$id = "temp";
         doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
-        expect(doc1.$id).toEqual(doc2.$id);
+        expect(doc1.$id).not.toEqual(doc2.$id);
+        expect(doc1.$id).toEqual("temp");
       });
       test('should not change if nothing is defined', function() {
         const doc: Schema = { };
@@ -477,6 +490,31 @@ describe('CommonModel', function() {
         doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
         expect(doc1.patternProperties).toBeUndefined();
       });
+    });
+  });
+
+  describe('addToTypes', function() {
+    test('should add multiple types', function() {
+      const model = new CommonModel(); 
+      model.addToTypes(['type1', 'type2']);
+      expect(model.type).toEqual(['type1', 'type2']);
+    });
+    test('should add type as is', function() {
+      const model = new CommonModel(); 
+      model.addToTypes('type');
+      expect(model.type).toEqual('type');
+    });
+    test('should add type to existing type', function() {
+      const model = new CommonModel(); 
+      model.type = ['type1'];
+      model.addToTypes('type2');
+      expect(model.type).toEqual(['type1', 'type2']);
+    });
+    test('should set an array when adding two types', function() {
+      const model = new CommonModel(); 
+      model.addToTypes('type1');
+      model.addToTypes('type2');
+      expect(model.type).toEqual(['type1', 'type2']);
     });
   });
   describe('helpers', function() {


### PR DESCRIPTION
**Description**
This PR introduces some more functions to `CommonModel`, which are going to be used as part of the further refactoring of the simplifier.

Furthermore, I added functionality to ensure that recursive `CommonModel`s are handles correctly when merging. With the current simplifier, this is not a problem so it is not a `fix:`.