### PR TITLE
fix: recursive schemas in AsyncAPI documents throw an error

### DIFF
--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -49,7 +49,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     if (typeof schema === 'boolean') return schema;
     const schemaUid = schema.uid();
     if (alreadyIteratedSchemas.has(schemaUid)) {
-      return alreadyIteratedSchemas.get(schemaUid); 
+      return alreadyIteratedSchemas.get(schemaUid) as Schema; 
     }
     let convertedSchema = new Schema();
     alreadyIteratedSchemas.set(schemaUid, convertedSchema);

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -27,7 +27,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     common.originalInput = doc;
     
     doc.allMessages().forEach((message) => {
-      const schema = AsyncAPIInputProcessor.reflectSchemaNames(message.payload());
+      const schema = AsyncAPIInputProcessor.convertToInternalSchema(message.payload());
       const commonModels = JsonSchemaInputProcessor.convertSchemaToCommonModel(schema);
       common.models = {...common.models, ...commonModels};
     });
@@ -42,7 +42,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
    * @param schema to reflect name for
    */
   // eslint-disable-next-line sonarjs/cognitive-complexity
-  static reflectSchemaNames(
+  static convertToInternalSchema(
     schema: AsyncAPISchema | boolean,
     alreadyIteratedSchemas: Map<string, Schema> = new Map()
   ): Schema | boolean {
@@ -57,56 +57,56 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     convertedSchema[this.MODELGEN_INFFERED_NAME] = schemaUid;
 
     if (schema.allOf() !== null) {
-      convertedSchema.allOf = schema.allOf().map((item) => this.reflectSchemaNames(item, alreadyIteratedSchemas));
+      convertedSchema.allOf = schema.allOf().map((item) => this.convertToInternalSchema(item, alreadyIteratedSchemas));
     }
     if (schema.oneOf() !== null) {
-      convertedSchema.oneOf = schema.oneOf().map((item) => this.reflectSchemaNames(item, alreadyIteratedSchemas));
+      convertedSchema.oneOf = schema.oneOf().map((item) => this.convertToInternalSchema(item, alreadyIteratedSchemas));
     }
     if (schema.anyOf() !== null) {
-      convertedSchema.anyOf = schema.anyOf().map((item) => this.reflectSchemaNames(item, alreadyIteratedSchemas));
+      convertedSchema.anyOf = schema.anyOf().map((item) => this.convertToInternalSchema(item, alreadyIteratedSchemas));
     }
     if (schema.not() !== null) {
-      convertedSchema.not = this.reflectSchemaNames(schema.not(), alreadyIteratedSchemas);
+      convertedSchema.not = this.convertToInternalSchema(schema.not(), alreadyIteratedSchemas);
     }
     if (
       typeof schema.additionalItems() === 'object' &&
       schema.additionalItems() !== null
     ) {
-      convertedSchema.additionalItems = this.reflectSchemaNames(schema.additionalItems(), alreadyIteratedSchemas);
+      convertedSchema.additionalItems = this.convertToInternalSchema(schema.additionalItems(), alreadyIteratedSchemas);
     }
     if (schema.contains() !== null) {
-      convertedSchema.contains = this.reflectSchemaNames(schema.contains(), alreadyIteratedSchemas);
+      convertedSchema.contains = this.convertToInternalSchema(schema.contains(), alreadyIteratedSchemas);
     }
     if (schema.propertyNames() !== null) {
-      convertedSchema.propertyNames = this.reflectSchemaNames(schema.propertyNames(), alreadyIteratedSchemas);
+      convertedSchema.propertyNames = this.convertToInternalSchema(schema.propertyNames(), alreadyIteratedSchemas);
     }
     if (schema.if() !== null) {
-      convertedSchema.if = this.reflectSchemaNames(schema.if(), alreadyIteratedSchemas);
+      convertedSchema.if = this.convertToInternalSchema(schema.if(), alreadyIteratedSchemas);
     }
     if (schema.then() !== null) {
-      convertedSchema.then = this.reflectSchemaNames(schema.then(), alreadyIteratedSchemas);
+      convertedSchema.then = this.convertToInternalSchema(schema.then(), alreadyIteratedSchemas);
     }
     if (schema.else() !== null) {
-      convertedSchema.else = this.reflectSchemaNames(schema.else(), alreadyIteratedSchemas);
+      convertedSchema.else = this.convertToInternalSchema(schema.else(), alreadyIteratedSchemas);
     }
     if (
       typeof schema.additionalProperties() === 'object' && 
       schema.additionalProperties() !== null
     ) {
-      convertedSchema.additionalProperties = this.reflectSchemaNames(schema.additionalProperties(), alreadyIteratedSchemas);
+      convertedSchema.additionalProperties = this.convertToInternalSchema(schema.additionalProperties(), alreadyIteratedSchemas);
     }
     if (schema.items() !== null) {
       if (Array.isArray(schema.items())) {
-        convertedSchema.items = (schema.items() as AsyncAPISchema[]).map((item) => this.reflectSchemaNames(item), alreadyIteratedSchemas);
+        convertedSchema.items = (schema.items() as AsyncAPISchema[]).map((item) => this.convertToInternalSchema(item), alreadyIteratedSchemas);
       } else {
-        convertedSchema.items = this.reflectSchemaNames(schema.items() as AsyncAPISchema, alreadyIteratedSchemas);
+        convertedSchema.items = this.convertToInternalSchema(schema.items() as AsyncAPISchema, alreadyIteratedSchemas);
       }
     }
 
     if (schema.properties() !== null && Object.keys(schema.properties()).length) {
       const properties : {[key: string]: Schema | boolean} = {};
       Object.entries(schema.properties()).forEach(([propertyName, propertySchema]) => {
-        properties[`${propertyName}`] = this.reflectSchemaNames(propertySchema, alreadyIteratedSchemas);
+        properties[`${propertyName}`] = this.convertToInternalSchema(propertySchema, alreadyIteratedSchemas);
       });
       convertedSchema.properties = properties;
     }
@@ -114,7 +114,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
       const dependencies: { [key: string]: Schema | boolean | string[] } = {};
       Object.entries(schema.dependencies()).forEach(([dependencyName, dependency]) => {
         if (typeof dependency === 'object' && !Array.isArray(dependency)) {
-          dependencies[`${dependencyName}`] = this.reflectSchemaNames(dependency, alreadyIteratedSchemas);
+          dependencies[`${dependencyName}`] = this.convertToInternalSchema(dependency, alreadyIteratedSchemas);
         } else {
           dependencies[`${dependencyName}`] = dependency as string[];
         }
@@ -124,14 +124,14 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     if (schema.patternProperties() !== null && Object.keys(schema.patternProperties()).length) {
       const patternProperties: { [key: string]: Schema | boolean } = {};
       Object.entries(schema.patternProperties()).forEach(([patternPropertyName, patternProperty]) => {
-        patternProperties[`${patternPropertyName}`] = this.reflectSchemaNames(patternProperty, alreadyIteratedSchemas);
+        patternProperties[`${patternPropertyName}`] = this.convertToInternalSchema(patternProperty, alreadyIteratedSchemas);
       });
       convertedSchema.patternProperties = patternProperties;
     }
     if (schema.definitions() !== null && Object.keys(schema.definitions()).length) {
       const definitions: { [key: string]: Schema | boolean } = {};
       Object.entries(schema.definitions()).forEach(([definitionName, definition]) => {
-        definitions[`${definitionName}`] = this.reflectSchemaNames(definition, alreadyIteratedSchemas);
+        definitions[`${definitionName}`] = this.convertToInternalSchema(definition, alreadyIteratedSchemas);
       });
       convertedSchema.definitions = definitions;
     }

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -159,8 +159,8 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
    */
   static isFromParser(input: any) {
     if (input._json !== undefined && 
-            input._json.asyncapi !== undefined && 
-            typeof input.version === 'function') {
+      input._json.asyncapi !== undefined && 
+      typeof input.version === 'function') {
       return true;
     }
     return false;

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -49,10 +49,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     if (typeof schema === 'boolean') return schema;
     const schemaUid = schema.uid();
     if (alreadyIteratedSchemas.has(schemaUid)) {
-      const cachedOutputSchema = alreadyIteratedSchemas.get(schemaUid); 
-      if (cachedOutputSchema !== undefined) {
-        return cachedOutputSchema;
-      }
+      return alreadyIteratedSchemas.get(schemaUid); 
     }
     let convertedSchema = new Schema();
     alreadyIteratedSchemas.set(schemaUid, convertedSchema);

--- a/test/processors/AsyncAPIInputProcessor.spec.ts
+++ b/test/processors/AsyncAPIInputProcessor.spec.ts
@@ -57,12 +57,12 @@ describe('AsyncAPIInputProcessor', function() {
         });
     });
 
-    describe('reflectSchemaName()', function() {
+    describe('convertToInternalSchema()', function() {
         test('should work', async function() {
             const basicDocString = fs.readFileSync(path.resolve(__dirname, './AsyncAPIInputProcessor/schema_name_reflection.json'), 'utf8');
             const doc = await parse(basicDocString);
             const schema = doc.channels()["/user/signedup"].subscribe().message().payload();
-            const expected = AsyncAPIInputProcessor.reflectSchemaNames(schema) as any;
+            const expected = AsyncAPIInputProcessor.convertToInternalSchema(schema) as any;
 
             // root
             expect(expected['x-modelgen-inferred-name']).toEqual('MainSchema');

--- a/test/processors/AsyncAPIInputProcessor.spec.ts
+++ b/test/processors/AsyncAPIInputProcessor.spec.ts
@@ -65,7 +65,7 @@ describe('AsyncAPIInputProcessor', function() {
             const expected = AsyncAPIInputProcessor.reflectSchemaNames(schema) as any;
 
             // root
-            expect(expected['x-modelgen-inferred-name']).toEqual('<anonymous-schema-1>');
+            expect(expected['x-modelgen-inferred-name']).toEqual('MainSchema');
 
             // properties
             expect(expected.properties.prop['x-modelgen-inferred-name']).toEqual('<anonymous-schema-2>');

--- a/test/processors/AsyncAPIInputProcessor/schema_name_reflection.json
+++ b/test/processors/AsyncAPIInputProcessor/schema_name_reflection.json
@@ -23,95 +23,105 @@
       "subscribe": {
         "message": {
           "payload": {
+            "$ref": "#/definitions/schemas/MainSchema"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "schemas": {
+      "MainSchema": {
+        "type": "object",
+        "x-parser-schema-id": "<anonymous-schema-1>",
+        "properties": {
+          "prop": {
+            "x-parser-schema-id": "<anonymous-schema-2>",
+            "type": "string"
+          },
+          "allOfCase": {
+            "x-parser-schema-id": "<anonymous-schema-3>",
+            "allOf": [
+              {
+                "x-parser-schema-id": "<anonymous-schema-4>",
+                "type": "string"
+              },
+              {
+                "x-parser-schema-id": "<anonymous-schema-5>",
+                "type": "string"
+              }
+            ]
+          },
+          "object": {
+            "x-parser-schema-id": "<anonymous-schema-6>",
             "type": "object",
-            "x-parser-schema-id": "<anonymous-schema-1>",
             "properties": {
               "prop": {
-                "x-parser-schema-id": "<anonymous-schema-2>",
+                "x-parser-schema-id": "<anonymous-schema-7>",
                 "type": "string"
-              },
-              "allOfCase": {
-                "x-parser-schema-id": "<anonymous-schema-3>",
-                "allOf": [
-                  {
-                    "x-parser-schema-id": "<anonymous-schema-4>",
-                    "type": "string"
-                  },
-                  {
-                    "x-parser-schema-id": "<anonymous-schema-5>",
-                    "type": "string"
-                  }
-                ]
-              },
-              "object": {
-                "x-parser-schema-id": "<anonymous-schema-6>",
-                "type": "object",
-                "properties": {
-                  "prop": {
-                    "x-parser-schema-id": "<anonymous-schema-7>",
-                    "type": "string"
-                  }
-                }
-              },
+              }
+            }
+          },
+          "propWithObject": {
+            "type": "object",
+            "x-parser-schema-id": "<anonymous-schema-8>",
+            "properties": {
               "propWithObject": {
-                "type": "object",
-                "x-parser-schema-id": "<anonymous-schema-8>",
-                "properties": {
-                  "propWithObject": {
-                    "x-parser-schema-id": "<anonymous-schema-9>",
-                    "type": "object"
-                  }
-                }
+                "x-parser-schema-id": "<anonymous-schema-9>",
+                "type": "object"
               }
-            },
-            "patternProperties": {
-              "patternProp": {
-                "x-parser-schema-id": "<anonymous-schema-10>",
-                "type": "string"
-              }
-            },
-            "dependencies": {
-              "dep": {
-                "x-parser-schema-id": "<anonymous-schema-11>",
-                "type": "string"
-              }
-            },
-            "definitions": {
-              "def": {
-                "x-parser-schema-id": "<anonymous-schema-12>",
-                "type": "string"
-              },
-              "oneOfCase": {
-                "x-parser-schema-id": "<anonymous-schema-13>",
-                "oneOf": [
-                  {
-                    "x-parser-schema-id": "<anonymous-schema-14>",
-                    "type": "string"
-                  },
-                  {
-                    "x-parser-schema-id": "<anonymous-schema-15>",
-                    "type": "string"
-                  }
-                ]
-              }
-            },
-            "anyOf": [
+            }
+          }
+        },
+        "patternProperties": {
+          "patternProp": {
+            "x-parser-schema-id": "<anonymous-schema-10>",
+            "type": "string"
+          }
+        },
+        "dependencies": {
+          "dep": {
+            "x-parser-schema-id": "<anonymous-schema-11>",
+            "type": "string"
+          }
+        },
+        "definitions": {
+          "def": {
+            "x-parser-schema-id": "<anonymous-schema-12>",
+            "type": "string"
+          },
+          "oneOfCase": {
+            "x-parser-schema-id": "<anonymous-schema-13>",
+            "oneOf": [
               {
-                "x-parser-schema-id": "<anonymous-schema-16>",
+                "x-parser-schema-id": "<anonymous-schema-14>",
                 "type": "string"
               },
               {
-                "type": "object",
-                "x-parser-schema-id": "<anonymous-schema-17>",
-                "properties": {
-                  "prop": {
-                    "x-parser-schema-id": "<anonymous-schema-18>",
-                    "type": "string"
-                  }
-                }
+                "x-parser-schema-id": "<anonymous-schema-15>",
+                "type": "string"
               }
             ]
           }
+        },
+        "anyOf": [
+          {
+            "x-parser-schema-id": "<anonymous-schema-16>",
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "x-parser-schema-id": "<anonymous-schema-17>",
+            "properties": {
+              "prop": {
+                "x-parser-schema-id": "<anonymous-schema-18>",
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "recursiveProp": {
+          "$ref": "#/definitions/schemas/MainSchema"
         }
       }
     }

--- a/test/processors/AsyncAPIInputProcessor/schema_name_reflection.json
+++ b/test/processors/AsyncAPIInputProcessor/schema_name_reflection.json
@@ -23,13 +23,13 @@
       "subscribe": {
         "message": {
           "payload": {
-            "$ref": "#/definitions/schemas/MainSchema"
+            "$ref": "#/components/schemas/MainSchema"
           }
         }
       }
     }
   },
-  "definitions": {
+  "components": {
     "schemas": {
       "MainSchema": {
         "type": "object",
@@ -71,6 +71,9 @@
                 "type": "object"
               }
             }
+          },
+          "recursiveProp": {
+            "$ref": "#/components/schemas/MainSchema"
           }
         },
         "patternProperties": {
@@ -119,10 +122,7 @@
               }
             }
           }
-        ],
-        "recursiveProp": {
-          "$ref": "#/definitions/schemas/MainSchema"
-        }
+        ]
       }
     }
   }


### PR DESCRIPTION
**Description**
This PR fixes the problem where recursive schemas in an AsyncAPI document throws stack size exceeding error.

**Related issue(s)**
fixes #199 