### PR TITLE
fix: array of items not supported by getNearestDependencies

### DIFF
--- a/src/generators/java/JavaRenderer.ts
+++ b/src/generators/java/JavaRenderer.ts
@@ -103,7 +103,7 @@ ${lines.map(line => ` * ${line}`).join('\n')}
           return value;
         }).filter(v => v !== undefined).join(', ');
       } else {
-        values = `${value}`;
+        values = value;
       }
     }
     return values !== undefined ? `${name}(${values})` : name;

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -31,7 +31,7 @@ ${this.indent(this.renderBlock(content, 2))}
     }
 
     const content = items.join(', ');
-    return String(content);
+    return `${content};`;
   }
 
   normalizeKey(value: any): string {

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -31,7 +31,7 @@ ${this.indent(this.renderBlock(content, 2))}
     }
 
     const content = items.join(', ');
-    return `${content};`;
+    return String(content);
   }
 
   normalizeKey(value: any): string {
@@ -52,7 +52,7 @@ ${this.indent(this.renderBlock(content, 2))}
     case 'string': {
       return `"${value}"`;
     }
-    default: return `${value}`;
+    default: return value;
     }
   }
 

--- a/src/generators/javascript/renderers/ClassRenderer.ts
+++ b/src/generators/javascript/renderers/ClassRenderer.ts
@@ -67,7 +67,7 @@ ${renderer.indent(body)}
   },
   property({ propertyName }) {
     propertyName = FormatHelpers.toCamelCase(propertyName);
-    return propertyName;
+    return `${propertyName};`;
   },
   getter({ propertyName }) {
     propertyName = FormatHelpers.toCamelCase(propertyName);

--- a/src/generators/javascript/renderers/ClassRenderer.ts
+++ b/src/generators/javascript/renderers/ClassRenderer.ts
@@ -67,7 +67,7 @@ ${renderer.indent(body)}
   },
   property({ propertyName }) {
     propertyName = FormatHelpers.toCamelCase(propertyName);
-    return `${propertyName};`;
+    return propertyName;
   },
   getter({ propertyName }) {
     propertyName = FormatHelpers.toCamelCase(propertyName);

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -54,7 +54,7 @@ export class Interpreter {
     if (splitModels) {
       this.ensureModelsAreSplit(model);
       if (isModelObject(model)) {
-        this.iteratedModels[`${model.$id}`] = model;
+        this.iteratedModels[String(model.$id)] = model;
       }
     }
     return [model, ...modelsToReturn];
@@ -129,7 +129,7 @@ export class Interpreter {
       Logger.info(`Splitting model ${model.$id || 'unknown'} since it should be on its own`);
       const switchRootModel = new CommonModel();
       switchRootModel.$ref = model.$id;
-      this.iteratedModels[`${model.$id}`] = model;
+      this.iteratedModels[String(model.$id)] = model;
       return switchRootModel;
     }
     return model;
@@ -146,7 +146,7 @@ export class Interpreter {
     if (model.properties) {
       const existingProperties = model.properties;
       for (const [prop, propSchema] of Object.entries(existingProperties)) {
-        model.properties[`${prop}`] = this.splitModels(propSchema);
+        model.properties[String(prop)] = this.splitModels(propSchema);
       }
     }
   }

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -123,11 +123,11 @@ export class CommonModel extends CommonSchema<CommonModel> {
    */
   addProperty(propertyName: string, propertyModel: CommonModel, schema: Schema) {
     if (this.properties === undefined) this.properties = {};
-    if (this.properties[`${propertyName}`] !== undefined) {
+    if (this.properties[String(propertyName)] !== undefined) {
       Logger.warn(`While trying to add property to model, duplicate properties found. Merging models together for property ${propertyName}`, propertyModel, schema, this);
-      this.properties[`${propertyName}`] = CommonModel.mergeCommonModels(this.properties[`${propertyName}`], propertyModel, schema);
+      this.properties[String(propertyName)] = CommonModel.mergeCommonModels(this.properties[String(propertyName)], propertyModel, schema);
     } else {
-      this.properties[`${propertyName}`] = propertyModel;
+      this.properties[String(propertyName)] = propertyModel;
     }
   }
 
@@ -157,11 +157,11 @@ export class CommonModel extends CommonSchema<CommonModel> {
    */
   addPatternProperty(pattern: string, patternModel: CommonModel, schema: Schema) {
     if (this.patternProperties ===  undefined) this.patternProperties = {};
-    if (this.patternProperties[`${pattern}`] !== undefined) {
+    if (this.patternProperties[String(pattern)] !== undefined) {
       Logger.warn(`While trying to add patternProperty to model, duplicate patterns found. Merging pattern models together for pattern ${pattern}`, patternModel, schema, this);
-      this.patternProperties[`${pattern}`] = CommonModel.mergeCommonModels(this.patternProperties[`${pattern}`], patternModel, schema);
+      this.patternProperties[String(pattern)] = CommonModel.mergeCommonModels(this.patternProperties[String(pattern)], patternModel, schema);
     } else {
-      this.patternProperties[`${pattern}`] = patternModel;
+      this.patternProperties[String(pattern)] = patternModel;
     }
   }
   
@@ -211,13 +211,13 @@ export class CommonModel extends CommonSchema<CommonModel> {
     if (this.properties !== undefined && Object.keys(this.properties).length) {
       const referencedProperties = Object.values(this.properties)
         .filter((propertyModel: CommonModel) => propertyModel.$ref !== undefined)
-        .map((propertyModel: CommonModel) => `${propertyModel.$ref}`);
+        .map((propertyModel: CommonModel) => String(propertyModel.$ref));
       dependsOn.push(...referencedProperties);
     }
     if (this.patternProperties !== undefined && Object.keys(this.patternProperties).length) {
       const referencedPatternProperties = Object.values(this.patternProperties)
         .filter((patternPropertyModel: CommonModel) => patternPropertyModel.$ref !== undefined)
-        .map((patternPropertyModel: CommonModel) => `${patternPropertyModel.$ref}`);
+        .map((patternPropertyModel: CommonModel) => String(patternPropertyModel.$ref));
       dependsOn.push(...referencedPatternProperties);
     }
     return dependsOn;
@@ -254,9 +254,9 @@ export class CommonModel extends CommonSchema<CommonModel> {
         mergeTo.properties = mergeFromProperties;
       } else {
         for (const [propName, prop] of Object.entries(mergeFromProperties)) {
-          if (mergeToProperties[`${propName}`] !== undefined) {
+          if (mergeToProperties[String(propName)] !== undefined) {
             Logger.warn(`Found duplicate properties ${propName} for model. Model property from ${mergeFrom.$id || 'unknown'} merged into ${mergeTo.$id || 'unknown'}`, mergeTo, mergeFrom, originalSchema);
-            mergeToProperties[`${propName}`] = CommonModel.mergeCommonModels(mergeToProperties[`${propName}`], prop, originalSchema, alreadyIteratedModels);
+            mergeToProperties[String(propName)] = CommonModel.mergeCommonModels(mergeToProperties[String(propName)], prop, originalSchema, alreadyIteratedModels);
           } else {
             mergeToProperties[String(propName)] = prop;
           }

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -201,11 +201,14 @@ export class CommonModel extends CommonSchema<CommonModel> {
         dependsOn.push(extendedSchema);
       }
     }
-    if (this.items instanceof CommonModel) {
-      const itemsRef = (this.items as CommonModel).$ref;
-      if (itemsRef !== undefined) {
-        dependsOn.push(itemsRef);
-      }
+    if (this.items !== undefined) {
+      const items = Array.isArray(this.items) ? this.items : [this.items];
+      items.forEach((item) => {
+        const itemRef = item.$ref;
+        if (itemRef !== undefined) {
+          dependsOn.push(itemRef);
+        }
+      });
     }
     if (this.properties !== undefined && Object.keys(this.properties).length) {
       const referencedProperties = Object.values(this.properties)

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -188,7 +188,7 @@ export class CommonModel extends CommonSchema<CommonModel> {
   /**
    * This function returns an array of `$id`s from all the CommonModel's it immediate depends on.
    */
-  getImmediateDependencies(): string[] {
+  getNearestDependencies(): string[] {
     const dependsOn = [];
     if (this.additionalProperties instanceof CommonModel) {
       const additionalPropertiesRef = (this.additionalProperties as CommonModel).$ref;

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -188,18 +188,16 @@ export class CommonModel extends CommonSchema<CommonModel> {
   /**
    * This function returns an array of `$id`s from all the CommonModel's it immediate depends on.
    */
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   getNearestDependencies(): string[] {
     const dependsOn = [];
-    if (this.additionalProperties instanceof CommonModel) {
-      const additionalPropertiesRef = (this.additionalProperties as CommonModel).$ref;
-      if (additionalPropertiesRef !== undefined) {
-        dependsOn.push(additionalPropertiesRef);
-      }
+    if (this.additionalProperties !== undefined && 
+      this.additionalProperties instanceof CommonModel && 
+      this.additionalProperties.$ref !== undefined) {
+      dependsOn.push(this.additionalProperties.$ref);
     }
     if (this.extend !== undefined) {
-      for (const extendedSchema of this.extend) {
-        dependsOn.push(extendedSchema);
-      }
+      dependsOn.push(...this.extend);
     }
     if (this.items !== undefined) {
       const items = Array.isArray(this.items) ? this.items : [this.items];
@@ -215,6 +213,12 @@ export class CommonModel extends CommonSchema<CommonModel> {
         .filter((propertyModel: CommonModel) => propertyModel.$ref !== undefined)
         .map((propertyModel: CommonModel) => `${propertyModel.$ref}`);
       dependsOn.push(...referencedProperties);
+    }
+    if (this.patternProperties !== undefined && Object.keys(this.patternProperties).length) {
+      const referencedPatternProperties = Object.values(this.patternProperties)
+        .filter((patternPropertyModel: CommonModel) => patternPropertyModel.$ref !== undefined)
+        .map((patternPropertyModel: CommonModel) => `${patternPropertyModel.$ref}`);
+      dependsOn.push(...referencedPatternProperties);
     }
     return dependsOn;
   }

--- a/test/generators/typescript/TypeScriptGenerator.spec.ts
+++ b/test/generators/typescript/TypeScriptGenerator.spec.ts
@@ -198,7 +198,7 @@ ${content}`;
       {
         interface: {
           self({ content }) {
-            return `${content}`;
+            return content;
           },
         }
       }
@@ -249,7 +249,7 @@ ${content}`;
       {
         enum: {
           self({ content }) {
-            return `${content}`;
+            return content;
           },
         }
       }

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -720,6 +720,11 @@ describe('CommonModel', function() {
     });
 
     describe('getImmediateDependencies', function() {
+      test('should work with array of items', function() {
+        const doc = { items: [{ $ref: "1" }] };
+        const d = CommonModel.toCommonModel(doc);
+        expect(d.getImmediateDependencies()).toEqual(["1"]);
+      });
       test('check that all dependencies are returned', function() {
         const doc = { additionalProperties: { $ref: "1" }, extend: ["2"], items: { $ref: "3" }, properties: { testProp: { $ref: "4" } }  };
         const d = CommonModel.toCommonModel(doc);

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -719,21 +719,21 @@ describe('CommonModel', function() {
       });
     });
 
-    describe('getImmediateDependencies', function() {
+    describe('getNearestDependencies', function() {
       test('should work with array of items', function() {
         const doc = { items: [{ $ref: "1" }] };
         const d = CommonModel.toCommonModel(doc);
-        expect(d.getImmediateDependencies()).toEqual(["1"]);
+        expect(d.getNearestDependencies()).toEqual(["1"]);
       });
       test('check that all dependencies are returned', function() {
         const doc = { additionalProperties: { $ref: "1" }, extend: ["2"], items: { $ref: "3" }, properties: { testProp: { $ref: "4" } }  };
         const d = CommonModel.toCommonModel(doc);
-        expect(d.getImmediateDependencies()).toEqual(["1", "2", "3", "4"]);
+        expect(d.getNearestDependencies()).toEqual(["1", "2", "3", "4"]);
       });
       test('check that no dependencies is returned if there are none', function() {
         const doc = {  };
         const d = CommonModel.toCommonModel(doc);
-        expect(d.getImmediateDependencies()).toEqual([]);
+        expect(d.getNearestDependencies()).toEqual([]);
       });
     });
   });

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -726,9 +726,9 @@ describe('CommonModel', function() {
         expect(d.getNearestDependencies()).toEqual(["1"]);
       });
       test('check that all dependencies are returned', function() {
-        const doc = { additionalProperties: { $ref: "1" }, extend: ["2"], items: { $ref: "3" }, properties: { testProp: { $ref: "4" } }  };
+        const doc = { additionalProperties: { $ref: "1" }, extend: ["2"], items: { $ref: "3" }, properties: { testProp: { $ref: "4" } }, patternProperties: {testPattern: {$ref: "5"}}  };
         const d = CommonModel.toCommonModel(doc);
-        expect(d.getNearestDependencies()).toEqual(["1", "2", "3", "4"]);
+        expect(d.getNearestDependencies()).toEqual(["1", "2", "3", "4", "5"]);
       });
       test('check that no dependencies is returned if there are none', function() {
         const doc = {  };


### PR DESCRIPTION
**Description**
This PR fixes an issue with an array of items not supported and then renames the function `getImmediateDependencies` to `getNearestDependencies`.

**Related issue(s)**
fixes https://github.com/asyncapi/generator-model-sdk/issues/122
fixes https://github.com/asyncapi/generator-model-sdk/issues/186