### PR TITLE
docs: clearify support of inputs in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm install @asyncapi/modelina
 
 ## AsyncAPI CLI
 
-If you have the [AsyncAPI CLI installed](https://github.com/asyncapi/cli#installation), you can run the following command to use [Modelina](https://github.com/asyncapi/cli#usage):
+If you have the [AsyncAPI CLI installed](https://github.com/asyncapi/cli#installation) (ONLY support AsyncAPI inputs), you can run the following command to use [Modelina](https://github.com/asyncapi/cli#usage):
 
 ```bash
 asyncapi generate models <language> ./asyncapi.json


### PR DESCRIPTION
This change tries to further clarify usage of the AsyncAPI CLI that it only supports AsyncAPI inputs even though Modelina supports a range of them.

I.e. avoid something like this: https://github.com/asyncapi/cli/issues/549