### PR TITLE
fix: python generation to follow more PEP8

### DIFF
--- a/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
@@ -62,13 +62,13 @@ exports[`Should be able to render python models and should generate \`implicit\`
 Array [
   "from __future__ import annotations
 from typing import Any, Dict
-from . import ObjProperty
+from modelina.obj_property import ObjProperty
 class Root: 
   def __init__(self, input: Dict):
     if 'email' in input:
       self._email: str = input['email']
     if 'obj_property' in input:
-      self._obj_property: ObjProperty.ObjProperty = ObjProperty.ObjProperty(input['obj_property'])
+      self._obj_property: ObjProperty = ObjProperty(input['obj_property'])
 
   @property
   def email(self) -> str:
@@ -78,10 +78,10 @@ class Root:
     self._email = email
 
   @property
-  def obj_property(self) -> ObjProperty.ObjProperty:
+  def obj_property(self) -> ObjProperty:
     return self._obj_property
   @obj_property.setter
-  def obj_property(self, obj_property: ObjProperty.ObjProperty):
+  def obj_property(self, obj_property: ObjProperty):
     self._obj_property = obj_property
 ",
 ]
@@ -91,13 +91,13 @@ exports[`Should be able to render python models and should generate \`implicit\`
 Array [
   "from __future__ import annotations
 from typing import Any, Dict
-from . import ObjProperty
+from modelina.obj_property import ObjProperty
 class Root: 
   def __init__(self, input: Dict):
     if 'email' in input:
       self._email: str = input['email']
     if 'obj_property' in input:
-      self._obj_property: ObjProperty.ObjProperty = ObjProperty.ObjProperty(input['obj_property'])
+      self._obj_property: ObjProperty = ObjProperty(input['obj_property'])
 
   @property
   def email(self) -> str:
@@ -107,10 +107,10 @@ class Root:
     self._email = email
 
   @property
-  def obj_property(self) -> ObjProperty.ObjProperty:
+  def obj_property(self) -> ObjProperty:
     return self._obj_property
   @obj_property.setter
-  def obj_property(self, obj_property: ObjProperty.ObjProperty):
+  def obj_property(self, obj_property: ObjProperty):
     self._obj_property = obj_property
 ",
 ]

--- a/examples/generate-python-complete-models/index.ts
+++ b/examples/generate-python-complete-models/index.ts
@@ -24,7 +24,8 @@ export async function generate(): Promise<void> {
   const generator = new PythonGenerator();
 
   let models = await generator.generateCompleteModels(jsonSchemaDraft7, {
-    importsStyle: 'implicit'
+    importsStyle: 'implicit',
+    packageName: 'modelina'
   });
 
   for (const model of models) {
@@ -32,7 +33,8 @@ export async function generate(): Promise<void> {
   }
 
   models = await generator.generateCompleteModels(jsonSchemaDraft7, {
-    importsStyle: 'explicit'
+    importsStyle: 'explicit',
+    packageName: 'modelina'
   });
 
   for (const model of models) {

--- a/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
@@ -6,7 +6,7 @@ Array [
   optional_field: Optional[str] = Field(description='''this field is optional''', default=None)
   required_field: str = Field(description='''this field is required''')
   no_description: Optional[str] = Field(default=None)
-  options: Optional[Options.Options] = Field(default=None)
+  options: Optional[Options] = Field(default=None)
   content_type: Optional[str] = Field(default=None)
 ",
 ]

--- a/modelina-cli/README.md
+++ b/modelina-cli/README.md
@@ -434,7 +434,7 @@ FLAGS
       --javaJackson               Java specific, generate the models with Jackson serialization support
       --namespace=<value>         C#, C++ and PHP specific, define the namespace to use for the generated models. This
                                   is required when language is `csharp`,`c++` or `php`.
-      --packageName=<value>       Go, Java and Kotlin specific, define the package to use for the generated models. This
+      --packageName=<value>       Go, Java, Python and Kotlin specific, define the package to use for the generated models. This
                                   is required when language is `go`, `java` or `kotlin`.
       --pyDantic                  Python specific, generate the Pydantic models.
       --tsEnumType=<option>       [default: enum] TypeScript specific, define which type of enums needs to be generated.

--- a/modelina-cli/src/helpers/python.ts
+++ b/modelina-cli/src/helpers/python.ts
@@ -18,8 +18,13 @@ export const PythonOclifFlags = {
  * @returns 
  */
 export function buildPythonGenerator(flags: any): BuilderReturnType {
-  const {pyDantic} = flags;
-  const presets = [];
+  const {packageName, pyDantic} = flags;
+
+  if (packageName === undefined) {
+    throw new Error('In order to generate models to Python, we need to know which package they are under. Add `--packageName=PACKAGENAME` to set the desired package name.');
+  }
+  
+  const presets = [];  
   if (pyDantic) {
     presets.push(PYTHON_PYDANTIC_PRESET);
   }

--- a/modelina-cli/test/integration/generate.test.ts
+++ b/modelina-cli/test/integration/generate.test.ts
@@ -120,7 +120,7 @@ describe('models', () => {
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'python', ASYNCAPI_V2_DOCUMENT, `-o=${ path.resolve(outputDir, './python')}`])
+      .command([...generalOptions, 'python', ASYNCAPI_V2_DOCUMENT, `-o=${ path.resolve(outputDir, './python')}`, '--packageName', 'test'])
       .it('works when file path is passed', (ctx, done) => {
         expect(ctx.stdout).to.contain(
           'Successfully generated the following models: '
@@ -130,11 +130,19 @@ describe('models', () => {
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'python', ASYNCAPI_V2_DOCUMENT, '--pyDantic'])
+      .command([...generalOptions, 'python', ASYNCAPI_V2_DOCUMENT, '--pyDantic', '--packageName', 'test'])
       .it('works when --pyDantic is set', (ctx, done) => {
         expect(ctx.stdout).to.contain(
           'Successfully generated the following models: '
         );
+        done();
+      });
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions, 'python', ASYNCAPI_V2_DOCUMENT, `-o=${ path.resolve(outputDir, './python')}`])
+      .it('fails when no package defined', (ctx, done) => {
+        expect(ctx.stderr).to.contain('Error: In order to generate models to Python, we need to know which package they are under. Add `--packageName=PACKAGENAME` to set the desired package name.\n');
         done();
       });
   });

--- a/modelina-website/src/components/playground/options/PythonGeneratorOptions.tsx
+++ b/modelina-website/src/components/playground/options/PythonGeneratorOptions.tsx
@@ -1,18 +1,65 @@
-import React from 'react';
+import { debounce } from 'lodash';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
+
+import { PlaygroundPythonConfigContext } from '@/components/contexts/PlaygroundConfigContext';
+import InfoModal from '@/components/InfoModal';
 
 interface PythonGeneratorOptionsProps {
   setNewConfig?: (queryKey: string, queryValue: any) => void;
 }
 
-interface PythonGeneratorState {}
+interface PythonGeneratorState {
+  packageName?: string;
+}
 
 export const defaultState: PythonGeneratorState = {};
 
-const PythonGeneratorOptions: React.FC<PythonGeneratorOptionsProps> = () => (
+const PythonGeneratorOptions: React.FC<PythonGeneratorOptionsProps> = ({ setNewConfig }) => {
+  const context = useContext(PlaygroundPythonConfigContext);
+  const [state, setState] = useState<PythonGeneratorState>(defaultState);
+
+  const debouncedSetNewConfig = debounce(
+    (queryKey: string, queryValue: any) => setNewConfig?.(queryKey, queryValue),
+    500
+  );
+
+  useEffect(() => {
+    setState({ ...state, packageName: context?.pythonPackageName });
+  }, [context?.pythonPackageName]);
+
+  const onChangePackageName = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const packageName = event.target.value;
+
+      setState({ ...state, packageName });
+      setNewConfig && debouncedSetNewConfig('pythonPackageName', packageName);
+    },
+    [setNewConfig, debouncedSetNewConfig, state]
+  );
+
+  return (
     <ul className='flex flex-col'>
       <h3 className='w-full border-b border-gray-700 py-2 text-left'>Python Specific options</h3>
-      <span className='mt-1 max-w-2xl text-sm text-gray-500'>Currently no options are available</span>
+      <li className='flex items-center gap-1'>
+        <InfoModal text='Package Name :'>
+          <p>
+            In Python, a package name is used to organize code into logical groups or containers. It serves as a namespace
+            for the code elements within it and helps in avoiding naming conflicts.
+          </p>
+        </InfoModal>
+        <label className='flex grow cursor-pointer items-center justify-between gap-1 py-2'>
+          <span className='mt-1 max-w-2xl text-sm text-gray-500'>Package Name</span>
+          <input
+            type='text'
+            className='text-md form-input w-[90%] cursor-pointer rounded-md border-gray-300 font-regular text-gray-700 focus-within:text-gray-900 hover:bg-gray-50'
+            name='pythonPackageName'
+            value={state?.packageName}
+            onChange={onChangePackageName}
+          />
+        </label>
+      </li>
     </ul>
   );
+};
 
 export default PythonGeneratorOptions;

--- a/modelina-website/src/pages/api/functions/PythonGenerator.ts
+++ b/modelina-website/src/pages/api/functions/PythonGenerator.ts
@@ -27,7 +27,9 @@ export async function getPythonModels(input: any, generatorOptions: ModelinaPyth
 
   try {
     const generator = new PythonGenerator(options);
-    const generatedModels = await generator.generateCompleteModels(input, {});
+    const generatedModels = await generator.generateCompleteModels(input, {
+      packageName: generatorOptions.pythonPackageName || 'asyncapimodels'
+    });
 
     return convertModelsToProps(generatedModels);
   } catch (e: any) {

--- a/modelina-website/src/types/index.ts
+++ b/modelina-website/src/types/index.ts
@@ -95,7 +95,9 @@ export interface ModelinaScalaOptions extends ModelinaGeneralOptions {
   scalaCollectionType: 'List' | 'Array' | undefined;
   scalaPackageName?: string;
 }
-export interface ModelinaPythonOptions extends ModelinaGeneralOptions {}
+export interface ModelinaPythonOptions extends ModelinaGeneralOptions {
+  pythonPackageName?: string;
+}
 export interface ModelinaDartOptions extends ModelinaGeneralOptions {}
 
 export interface ModelinaGeneralQueryOptions {
@@ -140,7 +142,9 @@ export interface ModelinaScalaQueryOptions {
   scalaCollectionType?: string;
   scalaPackageName?: string;
 }
-export interface ModelinaPythonQueryOptions {}
+export interface ModelinaPythonQueryOptions {
+  pythonPackageName?: string;
+}
 export interface ModelinaCplusplusQueryOptions {
   cplusplusNamespace?: string;
 }

--- a/src/generators/python/PythonConstrainer.ts
+++ b/src/generators/python/PythonConstrainer.ts
@@ -14,7 +14,7 @@ export const PythonDefaultTypeMapping: PythonTypeMapping = {
     return constrainedModel.name;
   },
   Reference({ constrainedModel }): string {
-    return `${constrainedModel.name}.${constrainedModel.name}`;
+    return `${constrainedModel.name}`;
   },
   Any({ dependencyManager }): string {
     dependencyManager.addDependency('from typing import Any');

--- a/src/generators/python/PythonDependencyManager.ts
+++ b/src/generators/python/PythonDependencyManager.ts
@@ -1,6 +1,7 @@
 import { ConstrainedMetaModel } from '../../models';
 import { AbstractDependencyManager } from '../AbstractDependencyManager';
 import { PythonOptions } from './PythonGenerator';
+import { FormatHelpers } from '../../helpers';
 
 export class PythonDependencyManager extends AbstractDependencyManager {
   constructor(
@@ -13,8 +14,8 @@ export class PythonDependencyManager extends AbstractDependencyManager {
   /**
    * Simple helper function to render a dependency based on the module system that the user defines.
    */
-  renderDependency(model: ConstrainedMetaModel): string {
-    return `from . import ${model.name}`;
+  renderDependency(model: ConstrainedMetaModel, packageName: string): string {
+    return `from ${packageName}.${FormatHelpers.snakeCase(model.name)} import ${model.name}`;
   }
 
   /**
@@ -41,7 +42,7 @@ export class PythonDependencyManager extends AbstractDependencyManager {
     const importMap: Record<string, string[]> = {};
     const dependenciesToRender = [];
     for (const dependency of individualDependencies) {
-      const regex = /from ([A-Za-z0-9]+) import ([A-Za-z0-9_\-,\s]+)/g;
+      const regex = /from ([A-Za-z0-9._]+) import ([A-Za-z0-9_\-,\s]+)/g;
       const matches = regex.exec(dependency);
 
       if (!matches) {

--- a/src/generators/python/PythonFileGenerator.ts
+++ b/src/generators/python/PythonFileGenerator.ts
@@ -2,7 +2,7 @@ import { PythonGenerator, PythonRenderCompleteModelOptions } from '.';
 import { InputMetaModel, OutputModel } from '../../models';
 import * as path from 'path';
 import { AbstractFileGenerator } from '../AbstractFileGenerator';
-import { FileHelpers } from '../../helpers';
+import { FileHelpers, FormatHelpers } from '../../helpers';
 
 export class PythonFileGenerator
   extends PythonGenerator
@@ -30,7 +30,7 @@ export class PythonFileGenerator
     for (const outputModel of generatedModels) {
       const filePath = path.resolve(
         outputDirectory,
-        `${outputModel.modelName}.py`
+        `${FormatHelpers.snakeCase(outputModel.modelName)}.py`
       );
       await FileHelpers.writerToFileSystem(
         outputModel.result,

--- a/src/generators/python/PythonGenerator.ts
+++ b/src/generators/python/PythonGenerator.ts
@@ -60,7 +60,9 @@ export type PythonTypeMapping = TypeMapping<
   PythonDependencyManager
 >;
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface PythonRenderCompleteModelOptions {}
+export interface PythonRenderCompleteModelOptions {
+  packageName: string;
+}
 
 /**
  * All the constrained models that do not depend on others to determine the type
@@ -92,7 +94,9 @@ export class PythonGenerator extends AbstractGenerator<
     }
   };
 
-  static defaultCompleteModelOptions: PythonRenderCompleteModelOptions = {};
+  static defaultCompleteModelOptions: PythonRenderCompleteModelOptions = {
+    packageName: 'asyncapimodels'
+  };
 
   constructor(options?: DeepPartial<PythonOptions>) {
     const realizedOptions = PythonGenerator.getPythonOptions(options);
@@ -213,6 +217,10 @@ export class PythonGenerator extends AbstractGenerator<
     >
   ): Promise<RenderOutput> {
     //const completeModelOptionsToUse = mergePartialAndDefault(PythonGenerator.defaultCompleteModelOptions, completeModelOptions) as PythonRenderCompleteModelOptions;
+    const completeModelOptionsToUse = mergePartialAndDefault(
+      PythonGenerator.defaultCompleteModelOptions,
+      args.completeOptions
+    ) as PythonRenderCompleteModelOptions;
     const optionsToUse = PythonGenerator.getPythonOptions({
       ...this.options,
       ...args.options
@@ -228,7 +236,10 @@ export class PythonGenerator extends AbstractGenerator<
     const modelDependencies = args.constrainedModel
       .getNearestDependencies()
       .map((model) => {
-        return dependencyManagerToUse.renderDependency(model);
+        return dependencyManagerToUse.renderDependency(
+          model,
+          completeModelOptionsToUse.packageName
+        );
       });
     const outputContent = `${outputModel.dependencies.join('\n')}
 ${modelDependencies.join('\n')}

--- a/test/generators/__snapshots__/FileGenerators.spec.ts.snap
+++ b/test/generators/__snapshots__/FileGenerators.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`generateToFiles should try and generate models to files 6`] = `"TestMod
 
 exports[`generateToFiles should try and generate models to files 7`] = `"test_model.rs"`;
 
-exports[`generateToFiles should try and generate models to files 8`] = `"TestModel.py"`;
+exports[`generateToFiles should try and generate models to files 8`] = `"test_model.py"`;
 
 exports[`generateToFiles should try and generate models to files 9`] = `"TestModel.kt"`;
 

--- a/test/generators/python/PythonConstrainer.spec.ts
+++ b/test/generators/python/PythonConstrainer.spec.ts
@@ -47,7 +47,7 @@ describe('PythonConstrainer', () => {
         constrainedModel: model,
         ...defaultOptions
       });
-      expect(type).toEqual(`${model.name}.${model.name}`);
+      expect(type).toEqual(`${model.name}`);
     });
   });
   describe('Any', () => {

--- a/test/generators/python/PythonGenerator.spec.ts
+++ b/test/generators/python/PythonGenerator.spec.ts
@@ -105,7 +105,10 @@ describe('PythonGenerator', () => {
         },
         additionalProperties: false
       };
-      const models = await generator.generate(doc);
+
+      const options = { packageName: 'test' };
+
+      const models = await generator.generate(doc, options);
       expect(models).toHaveLength(1);
       expect(models[0].result).toMatchSnapshot();
     });
@@ -137,7 +140,10 @@ describe('PythonGenerator', () => {
         },
         required: ['street_name', 'city', 'state', 'house_number', 'array_type']
       };
-      const models = await generator.generate(doc);
+
+      const options = { packageName: 'test' };
+
+      const models = await generator.generate(doc, options);
       expect(models).toHaveLength(1);
       expect(models[0].result).toMatchSnapshot();
     });
@@ -171,7 +177,9 @@ describe('PythonGenerator', () => {
         ]
       });
 
-      const models = await generator.generate(doc);
+      const options = { packageName: 'test' };
+
+      const models = await generator.generate(doc, options);
       expect(models).toHaveLength(1);
       expect(models[0].result).toMatchSnapshot();
     });

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`PYTHON_PYDANTIC_PRESET should render default value for discriminator wh
 Array [
   "",
   "class Car(BaseModel): 
-  vehicle_type: VehicleType.VehicleType = Field(default=VehicleType.VehicleType.CAR, frozen=True)
+  vehicle_type: VehicleType = Field(default=VehicleType.CAR, frozen=True)
   length: Optional[float] = Field(default=None)
   additional_properties: Optional[dict[str, Any]] = Field(default=None, exclude=True)
 
@@ -45,7 +45,7 @@ Array [
   CAR = \\"Car\\"
   TRUCK = \\"Truck\\"",
   "class Truck(BaseModel): 
-  vehicle_type: VehicleType.VehicleType = Field(default=VehicleType.VehicleType.TRUCK, frozen=True)
+  vehicle_type: VehicleType = Field(default=VehicleType.TRUCK, frozen=True)
   length: Optional[float] = Field(default=None)
   additional_properties: Optional[dict[str, Any]] = Field(default=None, exclude=True)
 
@@ -88,7 +88,7 @@ Array [
 exports[`PYTHON_PYDANTIC_PRESET should render nullable union 1`] = `
 Array [
   "class NullableUnionTest(BaseModel): 
-  nullable_union_test: Optional[Union[Union1.Union1]] = Field(default=None)
+  nullable_union_test: Optional[Union[Union1]] = Field(default=None)
   additional_properties: Optional[dict[str, Any]] = Field(default=None, exclude=True)
 
   @model_serializer(mode='wrap')
@@ -210,7 +210,7 @@ exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
 exports[`PYTHON_PYDANTIC_PRESET should render union to support Python < 3.10 1`] = `
 Array [
   "class UnionTest(BaseModel): 
-  union_test: Optional[Union[Union1.Union1, Union2.Union2]] = Field(default=None)
+  union_test: Optional[Union[Union1, Union2]] = Field(default=None)
   additional_properties: Optional[dict[str, Any]] = Field(default=None, exclude=True)
 
   @model_serializer(mode='wrap')

--- a/test/runtime/runtime-python.ts
+++ b/test/runtime/runtime-python.ts
@@ -14,7 +14,7 @@ generator.generateToFiles(
         __dirname,
         "./runtime-python/src/main/"
     ),
-    {}
+  {packageName : "main"}
 );
 
 

--- a/test/runtime/runtime-python/tests/main.py
+++ b/test/runtime/runtime-python/tests/main.py
@@ -1,6 +1,6 @@
 import unittest
-from src.main.Address import Address
-from src.main.NestedObject import NestedObject
+from src.main.address import Address
+from src.main.nested_object import NestedObject
 import json
     
 class TestAddress(unittest.TestCase):


### PR DESCRIPTION
## Description
the main goal is for Python generation to follow PEP8 standards and recommendations, which include:
- [PEP8](https://peps.python.org/pep-0008/#package-and-module-names) for module names
- [PEP8](https://peps.python.org/pep-0008/#imports) absolute imports, which brings a breaking change of package name to be provided (though it's a more of recommendation, modern Python development prefers absolute imports for clarity and it's the only way standard library imports are used in standard library).

## Related Issue
#2076 

## Checklist
- [X] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [X] Tests have been added or updated to cover the changes.
- [X] Documentation has been updated to reflect the changes.
- [X] All tests pass successfully locally.(`npm run test`).

## Additional Notes
the change is somewhat breaking, because it introduces a mandatory `packageName` to be provided in `modelina-cli`, though in generator there is a default value.
