### PR TITLE
fix: bump modelina version in modelina-cli dependencies

### DIFF
--- a/modelina-cli/package-lock.json
+++ b/modelina-cli/package-lock.json
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@asyncapi/modelina": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/modelina/-/modelina-5.2.1.tgz",
-      "integrity": "sha512-kYOX3x5BMN0f+JxiCEnkYBADHxFRt6Bwshib8pn89tfeb4dmk7f+/1m7l5LmUFw1segkrm1SKS9/MNgGZsRWCQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@asyncapi/modelina/-/modelina-5.2.4.tgz",
+      "integrity": "sha512-Sl6qjksz8EG2gODswZQJ/XTUxr1kfq914YUBigqNLzBZxJiAZ3WThxlRKYfgOcBwkwQUDtCs1Wiw4qOYNBE1bA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.1.0",


### PR DESCRIPTION
## Description
modelina version in modelina-cli dependencies requires upgrade all the time. perhaps, there is a better automation for it, but currently it is the only way.

## Related Issue
None

## Checklist
- [X] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [X] Tests have been added or updated to cover the changes.
- [X] Documentation has been updated to reflect the changes.
- [X] All tests pass successfully locally.(`npm run test`).

## Additional Notes
None
