### PR TITLE
fix: forward properly package name from cli args for Python

### DIFF
--- a/modelina-cli/README.md
+++ b/modelina-cli/README.md
@@ -434,7 +434,7 @@ FLAGS
       --javaJackson               Java specific, generate the models with Jackson serialization support
       --namespace=<value>         C#, C++ and PHP specific, define the namespace to use for the generated models. This
                                   is required when language is `csharp`,`c++` or `php`.
-      --packageName=<value>       Go, Java and Kotlin specific, define the package to use for the generated models. This
+      --packageName=<value>       Go, Java, Python and Kotlin specific, define the package to use for the generated models. This
                                   is required when language is `go`, `java` or `kotlin`.
       --pyDantic                  Python specific, generate the Pydantic models.
       --tsEnumType=<option>       [default: enum] TypeScript specific, define which type of enums needs to be generated.

--- a/modelina-cli/package-lock.json
+++ b/modelina-cli/package-lock.json
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@asyncapi/modelina": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/modelina/-/modelina-5.2.1.tgz",
-      "integrity": "sha512-kYOX3x5BMN0f+JxiCEnkYBADHxFRt6Bwshib8pn89tfeb4dmk7f+/1m7l5LmUFw1segkrm1SKS9/MNgGZsRWCQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@asyncapi/modelina/-/modelina-5.2.4.tgz",
+      "integrity": "sha512-Sl6qjksz8EG2gODswZQJ/XTUxr1kfq914YUBigqNLzBZxJiAZ3WThxlRKYfgOcBwkwQUDtCs1Wiw4qOYNBE1bA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.1.0",

--- a/modelina-cli/src/helpers/python.ts
+++ b/modelina-cli/src/helpers/python.ts
@@ -30,7 +30,9 @@ export function buildPythonGenerator(flags: any): BuilderReturnType {
   }
 
   const fileGenerator = new PythonFileGenerator({presets});
-  const fileOptions = undefined;
+  const fileOptions = {
+    packageName
+  };
   return {
     fileOptions,
     fileGenerator

--- a/modelina-cli/test/helpers/generate.test.ts
+++ b/modelina-cli/test/helpers/generate.test.ts
@@ -2,6 +2,7 @@ import { Languages, generateModels } from '../../src/helpers/generate';
 import fs from 'node:fs';
 import path from 'node:path';
 import { expect } from '@oclif/test';
+import {buildPythonGenerator} from '../../src/helpers/python'
 
 const AsyncapiV3Yaml = fs.readFileSync(
   path.resolve(__dirname, '../fixtures/asyncapi_v3.yml'),
@@ -38,5 +39,18 @@ describe('generate models', () => {
   it('should work with AsyncAPI v3 json input', async () => {
     const models = await generateModels({}, AsyncapiV3JSON, logger, Languages.typescript);
     expect(Object.keys(models).length).equal(1);
+  });
+
+  describe('for Python', () => {
+    it('should properly parse --packageName flag', async () => {
+      const {fileOptions, fileGenerator} = buildPythonGenerator({packageName: 'test'});
+      expect(fileOptions).to.have.property('packageName','test');
+      expect(fileGenerator.options.presets.length).equal(0);
+    });
+    it('should properly parse --pyDantic flag', async () => {
+      const {fileOptions, fileGenerator} = buildPythonGenerator({packageName: 'test', pyDantic: true});
+      expect(fileOptions).to.have.property('packageName','test');
+      expect(fileGenerator.options.presets.length).equal(1);
+    });
   });
 });

--- a/modelina-cli/test/integration/generate.test.ts
+++ b/modelina-cli/test/integration/generate.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
  
 import path from 'node:path';
+import fs from 'node:fs';
 import { expect, test } from '@oclif/test';
 const generalOptions = ['generate'];
 const outputDir = './test/fixtures/generate/models';
@@ -9,6 +10,7 @@ const ASYNCAPI_V2_DOCUMENT = path.resolve(__dirname, '../fixtures/asyncapi_v2.ym
 const ASYNCAPI_V3_DOCUMENT = path.resolve(__dirname, '../fixtures/asyncapi_v3.yml')
 
 describe('models', () => {
+  fs.rmSync(path.resolve(outputDir), { recursive: true, force: true });
   test
     .stderr()
     .stdout()
@@ -125,16 +127,18 @@ describe('models', () => {
         expect(ctx.stdout).to.contain(
           'Successfully generated the following models: '
         );
+        expect(fs.existsSync(path.resolve(outputDir, './python/user_signed_up_payload.py'))).to.equal(true);
         done();
       });
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'python', ASYNCAPI_V2_DOCUMENT, '--pyDantic', '--packageName', 'test'])
+      .command([...generalOptions, 'python', ASYNCAPI_V3_DOCUMENT, '--pyDantic', '--packageName', 'test', `-o=${ path.resolve(outputDir, './python/pydantic')}`])
       .it('works when --pyDantic is set', (ctx, done) => {
         expect(ctx.stdout).to.contain(
           'Successfully generated the following models: '
         );
+        expect(fs.existsSync(path.resolve(outputDir, './python/pydantic/user_signed_up_payload.py'))).to.equal(true);
         done();
       });
     test


### PR DESCRIPTION
## Description
A follow up PR fixing small missing bit of forwarding cli args to Python generator and adding additional tests.

## Related Issue
None

## Checklist
- [X] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [X] Tests have been added or updated to cover the changes.
- [X] Documentation has been updated to reflect the changes.
- [X] All tests pass successfully locally.(`npm run test`).

## Additional Notes
None
