### PR TITLE
fix: in pydantic serialization additional properties clashes with existing values

### DIFF
--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -110,7 +110,7 @@ def custom_serializer(self, handler):
   if ${dictionaryModel?.propertyName} is not None:
     for key, value in ${dictionaryModel?.propertyName}.items():
       # Never overwrite existing values, to avoid clashes
-      if not hasattr(serialized_self, key):
+      if not key in serialized_self:
         serialized_self[key] = value
 
   return serialized_self

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -13,7 +13,7 @@ Array [
     if additional_properties is not None:
       for key, value in additional_properties.items():
         # Never overwrite existing values, to avoid clashes
-        if not hasattr(serialized_self, key):
+        if not key in serialized_self:
           serialized_self[key] = value
 
     return serialized_self
@@ -57,7 +57,7 @@ Array [
     if additional_properties is not None:
       for key, value in additional_properties.items():
         # Never overwrite existing values, to avoid clashes
-        if not hasattr(serialized_self, key):
+        if not key in serialized_self:
           serialized_self[key] = value
 
     return serialized_self
@@ -95,7 +95,7 @@ Array [
     if additional_properties is not None:
       for key, value in additional_properties.items():
         # Never overwrite existing values, to avoid clashes
-        if not hasattr(serialized_self, key):
+        if not key in serialized_self:
           serialized_self[key] = value
 
     return serialized_self
@@ -136,7 +136,7 @@ Array [
     if additional_properties is not None:
       for key, value in additional_properties.items():
         # Never overwrite existing values, to avoid clashes
-        if not hasattr(serialized_self, key):
+        if not key in serialized_self:
           serialized_self[key] = value
 
     return serialized_self
@@ -178,7 +178,7 @@ Array [
     if additional_properties is not None:
       for key, value in additional_properties.items():
         # Never overwrite existing values, to avoid clashes
-        if not hasattr(serialized_self, key):
+        if not key in serialized_self:
           serialized_self[key] = value
 
     return serialized_self
@@ -215,7 +215,7 @@ Array [
     if additional_properties is not None:
       for key, value in additional_properties.items():
         # Never overwrite existing values, to avoid clashes
-        if not hasattr(serialized_self, key):
+        if not key in serialized_self:
           serialized_self[key] = value
 
     return serialized_self
@@ -259,7 +259,7 @@ exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
     if additional_properties is not None:
       for key, value in additional_properties.items():
         # Never overwrite existing values, to avoid clashes
-        if not hasattr(serialized_self, key):
+        if not key in serialized_self:
           serialized_self[key] = value
 
     return serialized_self
@@ -300,7 +300,7 @@ Array [
     if additional_properties is not None:
       for key, value in additional_properties.items():
         # Never overwrite existing values, to avoid clashes
-        if not hasattr(serialized_self, key):
+        if not key in serialized_self:
           serialized_self[key] = value
 
     return serialized_self
@@ -337,7 +337,7 @@ Array [
     if additional_properties is not None:
       for key, value in additional_properties.items():
         # Never overwrite existing values, to avoid clashes
-        if not hasattr(serialized_self, key):
+        if not key in serialized_self:
           serialized_self[key] = value
 
     return serialized_self
@@ -374,7 +374,7 @@ Array [
     if additional_properties is not None:
       for key, value in additional_properties.items():
         # Never overwrite existing values, to avoid clashes
-        if not hasattr(serialized_self, key):
+        if not key in serialized_self:
           serialized_self[key] = value
 
     return serialized_self


### PR DESCRIPTION
## Description
in `pydantic` serialization type of `serialized_self` is `dict`, thus existence of key must use `in` and not `hasattr`.

## Related Issue
Bug is small and has a one-liner fix, so I skipped issue creation.

## Checklist
- [X] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [X] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [X] All tests pass successfully locally.(`npm run test`).

## Additional Notes
None
