### PR TITLE
fix: ci not working for mac and block release 

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         # Using macos-13 instead of latest (macos-14) due to an issue with Puppeteer and such runner. 
         # See: https://github.com/puppeteer/puppeteer/issues/12327 and https://github.com/asyncapi/parser-js/issues/1001
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Set git to use LF #to once and for all finish neverending fight between Unix and Windows
         run: |


### PR DESCRIPTION
## Description
See https://github.com/actions/runner-images/issues/13046