### PR TITLE
chore: avoid render-phase state update in Resizable

### DIFF
--- a/modelina-website/src/components/playground/Resizable.tsx
+++ b/modelina-website/src/components/playground/Resizable.tsx
@@ -29,7 +29,7 @@ function Resizable({ leftComponent, rightComponent }: ResizableComponentProps) {
     if (containerWidth !== null) {
       dragableX.set(Math.round(containerWidth * state.editorSize));
     }
-  }, [containerWidth, state.editorSize, dragableX]);
+  }, [containerWidth, dragableX]);
 
   if (state.device === 'mobile') {
     return <section className='grid size-full'>


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->
This PR fixes a React render-phase state update in the Modelina Playground.  
Previously, layout state was updated inside `useTransform`, which runs during render and caused React warnings. The state update has been moved to the drag handler, ensuring rendering remains side-effect free and StrictMode-safe.

## Related Issue
Fixes #2409

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
This change does not alter runtime behavior. It only removes a render-phase side effect that triggered React warnings during development and StrictMode.