### PR TITLE
chore: update Docker base image to avoid EOL Debian Buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ RUN apt-get update -yq \
     && apt-get install -yq php php-cli php-common php-xml php-mbstring php-curl
 
 # Setup library
-RUN apt-get install -yq chromium-browser || true
+RUN apt-get install -yq chromium-browser


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->
This pull request fixes failing Docker builds caused by the base image using **Debian Buster**, which has reached **End of Life (EOL)** and whose repositories are no longer available.

The Dockerfile has been updated to use a supported base image and compatible package sources so that `docker build .` works correctly on a clean system.
## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->
Closes #2412
## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
- Updated base image from `openjdk:16.0.1-jdk-slim-buster` to `eclipse-temurin:17-jdk-jammy`
- Replaced EOL Debian repositories with supported Ubuntu repositories
- Replaced deprecated `python` package with `python3`
- Updated PHP and Chromium installation to Ubuntu-compatible packages

This restores the ability to build the project from a clean environment.
