### PR TITLE
feat: add tests and migration docs for using message name for anonymous payload schemas

### DIFF
--- a/docs/migrations/version-5-to-6.md
+++ b/docs/migrations/version-5-to-6.md
@@ -110,6 +110,61 @@ Generated model: `AnonymousSchema_1` or `<anonymous-message-1>Payload`
 **After (v6):**
 Generated model: `UserSignedupPayload` (derived from channel path `/user/signedup`)
 
+#### Named messages with anonymous payloads (fixes #1996)
+
+When using named messages in `components/messages` with inline (anonymous) payload schemas, the generated model now uses the message name instead of generic `AnonymousSchema_1`.
+
+**Before (v5):**
+
+```yaml
+asyncapi: 2.2.0
+info:
+  title: Account Service
+  version: 1.0.0
+channels:
+  user/signedup:
+    subscribe:
+      message:
+        $ref: '#/components/messages/UserSignedUp'
+components:
+  messages:
+    UserSignedUp:
+      payload:
+        type: object
+        properties:
+          displayName:
+            type: string
+          email:
+            type: string
+            format: email
+```
+
+Generated model: `AnonymousSchema_1`
+
+**After (v6):**
+
+Generated model: `UserSignedUpPayload` (derived from message name `UserSignedUp`)
+
+This also works for AsyncAPI v3 named messages:
+
+```yaml
+asyncapi: 3.0.0
+channels:
+  userSignedUp:
+    address: user/signedup
+    messages:
+      UserSignedUpMessage:
+        payload:
+          type: object
+          properties:
+            displayName:
+              type: string
+            email:
+              type: string
+```
+
+Generated model: `UserSignedUpMessagePayload` (derived from message name `UserSignedUpMessage`)
+
 #### Hierarchical naming for nested schemas
 
 Nested schemas in properties, `allOf`, `oneOf`, `anyOf`, `dependencies`, and `definitions` now receive hierarchical names based on their parent schema and property path.

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -334,14 +334,15 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
 
                 // Add each individual message payload as a separate model
                 const messageId = message.id();
-                // Use message ID if available, otherwise use channel name
+                const messageName = message.name();
+                // Use message ID if available, then message name, otherwise use channel name
                 const contextId =
                   messageId &&
                   !messageId.includes(
                     AsyncAPIInputProcessor.ANONYMOUS_MESSAGE_PREFIX
                   )
                     ? messageId
-                    : contextChannelName;
+                    : messageName || contextChannelName;
                 const messageContext: SchemaContext = contextId
                   ? { messageId: contextId }
                   : {};
@@ -364,14 +365,15 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
               if (payload) {
                 // Use message ID as context for better naming
                 const messageId = message.id();
-                // Use message ID if available, otherwise use channel name
+                const messageName = message.name();
+                // Use message ID if available, then message name, otherwise use channel name
                 const contextId =
                   messageId &&
                   !messageId.includes(
                     AsyncAPIInputProcessor.ANONYMOUS_MESSAGE_PREFIX
                   )
                     ? messageId
-                    : contextChannelName;
+                    : messageName || contextChannelName;
                 const messageContext: SchemaContext = contextId
                   ? { messageId: contextId }
                   : {};
@@ -398,10 +400,11 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
       for (const message of doc.allMessages()) {
         const payload = message.payload();
         if (payload) {
-          // Use message id with 'Payload' suffix as the inferred name for the payload schema
+          // Use message id or message name with 'Payload' suffix as the inferred name for the payload schema
           // This avoids potential collisions with component schemas that might have the same name
-          const messageName = message.id()
-            ? `${message.id()}Payload`
+          const messageIdentifier = message.id() || message.name();
+          const messageName = messageIdentifier
+            ? `${messageIdentifier}Payload`
             : undefined;
           addToInputModel(payload, messageName);
         }


### PR DESCRIPTION

## Description
- Add tests for issue #1996 covering v2 and v3 named messages with anonymous payloads
- Add migration docs section explaining the naming behavior change in version-5-to-6.md
- Target next branch as this is a breaking change

## Related Issue
#1996 

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).
