### PR TITLE
test: add XSD constraint and content parsing coverage (closes #2439)

### DIFF
--- a/test/processors/XsdInputProcessor.spec.ts
+++ b/test/processors/XsdInputProcessor.spec.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { XsdInputProcessor } from '../../src/processors';
+import { XsdSchema } from '../../src/models/XsdSchema';
 
 const basicDoc = fs.readFileSync(
   path.resolve(__dirname, './XsdInputProcessor/basic.xsd'),
@@ -19,6 +20,26 @@ const attributesDoc = fs.readFileSync(
 
 const arrayDoc = fs.readFileSync(
   path.resolve(__dirname, './XsdInputProcessor/array.xsd'),
+  'utf8'
+);
+
+const simpleContentDoc = fs.readFileSync(
+  path.resolve(__dirname, './XsdInputProcessor/simple-content.xsd'),
+  'utf8'
+);
+
+const complexContentDoc = fs.readFileSync(
+  path.resolve(__dirname, './XsdInputProcessor/complex-content.xsd'),
+  'utf8'
+);
+
+const patternRestrictionsDoc = fs.readFileSync(
+  path.resolve(__dirname, './XsdInputProcessor/pattern-restrictions.xsd'),
+  'utf8'
+);
+
+const inlineSimpleTypeDoc = fs.readFileSync(
+  path.resolve(__dirname, './XsdInputProcessor/inline-simple-type.xsd'),
   'utf8'
 );
 
@@ -154,6 +175,456 @@ describe('XsdInputProcessor', () => {
       expect(result).toBeDefined();
       expect(result.models).toBeDefined();
       expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe('simpleContent parsing', () => {
+    test('should process XSD with simpleContent extension', async () => {
+      const processor = new XsdInputProcessor();
+      const result = await processor.process(simpleContentDoc);
+      expect(result).toBeDefined();
+      expect(result.models).toBeDefined();
+      expect(result).toMatchSnapshot();
+    });
+
+    test('should parse simpleContent extension directly via XsdSchema', () => {
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="ExtendedString">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="lang" type="xs:language" use="optional" default="en"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      expect(schema.complexTypes).toBeDefined();
+      expect(schema.complexTypes!.length).toBe(1);
+      const ct = schema.complexTypes![0];
+      expect(ct.name).toBe('ExtendedString');
+      expect(ct.simpleContent).toBeDefined();
+      expect(ct.simpleContent!.extension).toBeDefined();
+      expect(ct.simpleContent!.extension!.base).toBe('xs:string');
+      expect(ct.simpleContent!.extension!.attributes).toBeDefined();
+      expect(ct.simpleContent!.extension!.attributes!.length).toBe(1);
+      expect(ct.simpleContent!.extension!.attributes![0].name).toBe('lang');
+    });
+
+    test('should handle simpleContent with no inner nodes', () => {
+      // When simpleContent is empty (empty string in parsed XML), the fast-xml-parser
+      // returns an empty string for the node, so parseComplexType sees it as falsy and
+      // skips setting simpleContent entirely.
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="EmptySimpleContent">
+    <xs:simpleContent>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      expect(schema.complexTypes).toBeDefined();
+      const ct = schema.complexTypes![0];
+      // Empty simpleContent is skipped by the parser (falsy empty string node)
+      expect(ct.simpleContent).toBeUndefined();
+    });
+  });
+
+  describe('complexContent parsing', () => {
+    test('should process XSD with complexContent extension', async () => {
+      const processor = new XsdInputProcessor();
+      const result = await processor.process(complexContentDoc);
+      expect(result).toBeDefined();
+      expect(result.models).toBeDefined();
+      expect(result).toMatchSnapshot();
+    });
+
+    test('should parse complexContent extension via XsdSchema', () => {
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="Vehicle">
+    <xs:sequence>
+      <xs:element name="make" type="xs:string"/>
+      <xs:element name="model" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Car">
+    <xs:complexContent>
+      <xs:extension base="Vehicle">
+        <xs:sequence>
+          <xs:element name="doors" type="xs:int"/>
+        </xs:sequence>
+        <xs:attribute name="vin" type="xs:string" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      expect(schema.complexTypes).toBeDefined();
+      expect(schema.complexTypes!.length).toBe(2);
+      const car = schema.complexTypes!.find((ct) => ct.name === 'Car');
+      expect(car).toBeDefined();
+      expect(car!.complexContent).toBeDefined();
+      expect(car!.complexContent!.extension).toBeDefined();
+      expect(car!.complexContent!.extension!.base).toBe('Vehicle');
+      expect(car!.complexContent!.extension!.sequence).toBeDefined();
+      expect(
+        car!.complexContent!.extension!.sequence!.elements!.length
+      ).toBe(1);
+      expect(car!.complexContent!.extension!.attributes).toBeDefined();
+      expect(car!.complexContent!.extension!.attributes!.length).toBe(1);
+      expect(car!.complexContent!.extension!.attributes![0].name).toBe('vin');
+    });
+
+    test('should parse complexContent extension with no sequence', () => {
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="NamedBase">
+    <xs:sequence>
+      <xs:element name="id" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NamedChild">
+    <xs:complexContent>
+      <xs:extension base="NamedBase">
+        <xs:attribute name="extra" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      const child = schema.complexTypes!.find((ct) => ct.name === 'NamedChild');
+      expect(child!.complexContent!.extension!.sequence).toBeUndefined();
+      expect(child!.complexContent!.extension!.attributes).toBeDefined();
+    });
+  });
+
+  describe('simpleType constraint parsing', () => {
+    test('should process XSD with pattern and length restrictions', async () => {
+      const processor = new XsdInputProcessor();
+      const result = await processor.process(patternRestrictionsDoc);
+      expect(result).toBeDefined();
+      expect(result.models).toBeDefined();
+      expect(result).toMatchSnapshot();
+    });
+
+    test('should parse pattern restriction via XsdSchema', () => {
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="ZipCode">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9]{5}(-[0-9]{4})?"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      expect(schema.simpleTypes).toBeDefined();
+      expect(schema.simpleTypes!.length).toBe(1);
+      const st = schema.simpleTypes![0];
+      expect(st.name).toBe('ZipCode');
+      expect(st.restriction).toBeDefined();
+      expect(st.restriction!.base).toBe('xs:string');
+      expect(st.restriction!.pattern).toBeDefined();
+      expect(st.restriction!.pattern).toBe('[0-9]{5}(-[0-9]{4})?');
+    });
+
+    test('should parse minLength and maxLength restrictions', () => {
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="Username">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="3"/>
+      <xs:maxLength value="32"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      const st = schema.simpleTypes![0];
+      expect(st.restriction!.minLength).toBe(3);
+      expect(st.restriction!.maxLength).toBe(32);
+    });
+
+    test('should parse minInclusive and maxInclusive numeric constraints', () => {
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="PositiveScore">
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="1"/>
+      <xs:maxInclusive value="10"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      const st = schema.simpleTypes![0];
+      expect(st.restriction!.minInclusive).toBe(1);
+      expect(st.restriction!.maxInclusive).toBe(10);
+    });
+
+    test('should parse minLength-only restriction', () => {
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="NonEmpty">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      const st = schema.simpleTypes![0];
+      expect(st.restriction!.minLength).toBe(1);
+      expect(st.restriction!.maxLength).toBeUndefined();
+    });
+
+    test('should parse maxLength-only restriction', () => {
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="ShortLabel">
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="20"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      const st = schema.simpleTypes![0];
+      expect(st.restriction!.maxLength).toBe(20);
+      expect(st.restriction!.minLength).toBeUndefined();
+    });
+
+    test('should parse minInclusive-only numeric constraint', () => {
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="PositiveInt">
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      const st = schema.simpleTypes![0];
+      expect(st.restriction!.minInclusive).toBe(1);
+      expect(st.restriction!.maxInclusive).toBeUndefined();
+    });
+
+    test('should parse maxInclusive-only numeric constraint', () => {
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="MaxHundred">
+    <xs:restriction base="xs:integer">
+      <xs:maxInclusive value="100"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      const st = schema.simpleTypes![0];
+      expect(st.restriction!.maxInclusive).toBe(100);
+      expect(st.restriction!.minInclusive).toBeUndefined();
+    });
+  });
+
+  describe('inline simpleType within element', () => {
+    test('should process XSD with inline simpleType in element', async () => {
+      const processor = new XsdInputProcessor();
+      const result = await processor.process(inlineSimpleTypeDoc);
+      expect(result).toBeDefined();
+      expect(result.models).toBeDefined();
+      expect(result).toMatchSnapshot();
+    });
+
+    test('should parse element with inline simpleType via XsdSchema', () => {
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Order">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="priority">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="low"/>
+              <xs:enumeration value="medium"/>
+              <xs:enumeration value="high"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      expect(schema.elements).toBeDefined();
+      const order = schema.elements![0];
+      expect(order.name).toBe('Order');
+      expect(order.complexType).toBeDefined();
+      expect(order.complexType!.sequence).toBeDefined();
+      const priorityElement = order.complexType!.sequence!.elements![0];
+      expect(priorityElement.name).toBe('priority');
+      expect(priorityElement.simpleType).toBeDefined();
+      expect(priorityElement.simpleType!.restriction).toBeDefined();
+      expect(priorityElement.simpleType!.restriction!.enumeration).toBeDefined();
+      expect(priorityElement.simpleType!.restriction!.enumeration!.length).toBe(
+        3
+      );
+    });
+  });
+
+  describe('XsdSchema.toSchema edge cases', () => {
+    test('should return empty schema for empty object input', () => {
+      // Passing {} results in no xs:schema or schema key, so schema fields remain undefined
+      const schema = XsdSchema.toSchema({});
+      expect(schema).toBeDefined();
+      expect(schema.elements).toBeUndefined();
+      expect(schema.complexTypes).toBeUndefined();
+      expect(schema.simpleTypes).toBeUndefined();
+    });
+
+    test('should return empty schema for input without xs:schema node', () => {
+      const schema = XsdSchema.toSchema({});
+      expect(schema).toBeDefined();
+      expect(schema.elements).toBeUndefined();
+    });
+
+    test('should parse schema targetNamespace and form defaults', () => {
+      const xsd = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://example.com/ns"
+  elementFormDefault="qualified"
+  attributeFormDefault="unqualified">
+  <xs:element name="Root" type="xs:string"/>
+</xs:schema>`;
+
+      const { XMLParser } = require('fast-xml-parser');
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: true,
+        trimValues: true
+      });
+      const parsed = parser.parse(xsd);
+      const schema = XsdSchema.toSchema(parsed);
+
+      expect(schema.targetNamespace).toBe('http://example.com/ns');
+      expect(schema.elementFormDefault).toBe('qualified');
+      expect(schema.attributeFormDefault).toBe('unqualified');
     });
   });
 });

--- a/test/processors/XsdInputProcessor.spec.ts
+++ b/test/processors/XsdInputProcessor.spec.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { XMLParser } from 'fast-xml-parser';
 import { XsdInputProcessor } from '../../src/processors';
 import { XsdSchema } from '../../src/models/XsdSchema';
 
@@ -199,7 +200,6 @@ describe('XsdInputProcessor', () => {
   </xs:complexType>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -233,7 +233,6 @@ describe('XsdInputProcessor', () => {
   </xs:complexType>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -280,7 +279,6 @@ describe('XsdInputProcessor', () => {
   </xs:complexType>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -298,9 +296,9 @@ describe('XsdInputProcessor', () => {
       expect(car!.complexContent!.extension).toBeDefined();
       expect(car!.complexContent!.extension!.base).toBe('Vehicle');
       expect(car!.complexContent!.extension!.sequence).toBeDefined();
-      expect(
-        car!.complexContent!.extension!.sequence!.elements!.length
-      ).toBe(1);
+      expect(car!.complexContent!.extension!.sequence!.elements!.length).toBe(
+        1
+      );
       expect(car!.complexContent!.extension!.attributes).toBeDefined();
       expect(car!.complexContent!.extension!.attributes!.length).toBe(1);
       expect(car!.complexContent!.extension!.attributes![0].name).toBe('vin');
@@ -323,7 +321,6 @@ describe('XsdInputProcessor', () => {
   </xs:complexType>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -358,7 +355,6 @@ describe('XsdInputProcessor', () => {
   </xs:simpleType>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -389,7 +385,6 @@ describe('XsdInputProcessor', () => {
   </xs:simpleType>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -415,7 +410,6 @@ describe('XsdInputProcessor', () => {
   </xs:simpleType>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -440,7 +434,6 @@ describe('XsdInputProcessor', () => {
   </xs:simpleType>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -465,7 +458,6 @@ describe('XsdInputProcessor', () => {
   </xs:simpleType>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -490,7 +482,6 @@ describe('XsdInputProcessor', () => {
   </xs:simpleType>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -515,7 +506,6 @@ describe('XsdInputProcessor', () => {
   </xs:simpleType>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -560,7 +550,6 @@ describe('XsdInputProcessor', () => {
   </xs:element>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -579,7 +568,9 @@ describe('XsdInputProcessor', () => {
       expect(priorityElement.name).toBe('priority');
       expect(priorityElement.simpleType).toBeDefined();
       expect(priorityElement.simpleType!.restriction).toBeDefined();
-      expect(priorityElement.simpleType!.restriction!.enumeration).toBeDefined();
+      expect(
+        priorityElement.simpleType!.restriction!.enumeration
+      ).toBeDefined();
       expect(priorityElement.simpleType!.restriction!.enumeration!.length).toBe(
         3
       );
@@ -612,7 +603,6 @@ describe('XsdInputProcessor', () => {
   <xs:element name="Root" type="xs:string"/>
 </xs:schema>`;
 
-      const { XMLParser } = require('fast-xml-parser');
       const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',

--- a/test/processors/XsdInputProcessor/complex-content.xsd
+++ b/test/processors/XsdInputProcessor/complex-content.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <!-- Base type -->
+  <xs:complexType name="Animal">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string"/>
+      <xs:element name="age" type="xs:int"/>
+    </xs:sequence>
+    <xs:attribute name="species" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- Extension via complexContent -->
+  <xs:complexType name="Dog">
+    <xs:complexContent>
+      <xs:extension base="Animal">
+        <xs:sequence>
+          <xs:element name="breed" type="xs:string"/>
+          <xs:element name="trained" type="xs:boolean"/>
+        </xs:sequence>
+        <xs:attribute name="registrationId" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="pet" type="Dog"/>
+</xs:schema>

--- a/test/processors/XsdInputProcessor/inline-simple-type.xsd
+++ b/test/processors/XsdInputProcessor/inline-simple-type.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <!-- Element with inline simpleType -->
+  <xs:element name="Product">
+    <xs:complexType>
+      <xs:sequence>
+        <!-- Inline simpleType on element -->
+        <xs:element name="status">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="active"/>
+              <xs:enumeration value="inactive"/>
+              <xs:enumeration value="pending"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="sku">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:pattern value="[A-Z]{3}-[0-9]{4}"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="quantity" type="xs:int"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test/processors/XsdInputProcessor/pattern-restrictions.xsd
+++ b/test/processors/XsdInputProcessor/pattern-restrictions.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <!-- Pattern restriction -->
+  <xs:simpleType name="EmailType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- minLength / maxLength restrictions -->
+  <xs:simpleType name="PasswordType">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="8"/>
+      <xs:maxLength value="128"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Numeric range constraints -->
+  <xs:simpleType name="PercentageType">
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="1"/>
+      <xs:maxInclusive value="100"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- minLength only -->
+  <xs:simpleType name="NonEmptyString">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- maxLength only -->
+  <xs:simpleType name="ShortLabel">
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="20"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="email" type="EmailType"/>
+  <xs:element name="password" type="PasswordType"/>
+  <xs:element name="percentage" type="PercentageType"/>
+</xs:schema>

--- a/test/processors/XsdInputProcessor/simple-content.xsd
+++ b/test/processors/XsdInputProcessor/simple-content.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <!-- ComplexType with simpleContent extension (adds an attribute to a base simple type) -->
+  <xs:complexType name="PersonType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="id" type="xs:int" use="required"/>
+        <xs:attribute name="lang" type="xs:string" use="optional" default="en"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- ComplexType with simpleContent restriction -->
+  <xs:complexType name="ShortString">
+    <xs:simpleContent>
+      <xs:restriction base="xs:string">
+        <xs:maxLength value="50"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="Person" type="PersonType"/>
+</xs:schema>

--- a/test/processors/__snapshots__/XsdInputProcessor.spec.ts.snap
+++ b/test/processors/__snapshots__/XsdInputProcessor.spec.ts.snap
@@ -295,6 +295,860 @@ InputMetaModel {
 }
 `;
 
+exports[`XsdInputProcessor complexContent parsing should process XSD with complexContent extension 1`] = `
+InputMetaModel {
+  "models": Object {
+    "Animal": ObjectModel {
+      "name": "Animal",
+      "options": Object {},
+      "originalInput": Object {
+        "?xml": Object {
+          "@_encoding": "UTF-8",
+          "@_version": 1,
+        },
+        "xs:schema": Object {
+          "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+          "xs:complexType": Array [
+            Object {
+              "@_name": "Animal",
+              "xs:attribute": Object {
+                "@_name": "species",
+                "@_type": "xs:string",
+                "@_use": "required",
+              },
+              "xs:sequence": Object {
+                "xs:element": Array [
+                  Object {
+                    "@_name": "name",
+                    "@_type": "xs:string",
+                  },
+                  Object {
+                    "@_name": "age",
+                    "@_type": "xs:int",
+                  },
+                ],
+              },
+            },
+            Object {
+              "@_name": "Dog",
+              "xs:complexContent": Object {
+                "xs:extension": Object {
+                  "@_base": "Animal",
+                  "xs:attribute": Object {
+                    "@_name": "registrationId",
+                    "@_type": "xs:string",
+                  },
+                  "xs:sequence": Object {
+                    "xs:element": Array [
+                      Object {
+                        "@_name": "breed",
+                        "@_type": "xs:string",
+                      },
+                      Object {
+                        "@_name": "trained",
+                        "@_type": "xs:boolean",
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+          "xs:element": Object {
+            "@_name": "pet",
+            "@_type": "Dog",
+          },
+        },
+      },
+      "properties": Object {
+        "age": ObjectPropertyModel {
+          "property": IntegerModel {
+            "name": "age",
+            "options": Object {},
+            "originalInput": Object {
+              "?xml": Object {
+                "@_encoding": "UTF-8",
+                "@_version": 1,
+              },
+              "xs:schema": Object {
+                "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                "xs:complexType": Array [
+                  Object {
+                    "@_name": "Animal",
+                    "xs:attribute": Object {
+                      "@_name": "species",
+                      "@_type": "xs:string",
+                      "@_use": "required",
+                    },
+                    "xs:sequence": Object {
+                      "xs:element": Array [
+                        Object {
+                          "@_name": "name",
+                          "@_type": "xs:string",
+                        },
+                        Object {
+                          "@_name": "age",
+                          "@_type": "xs:int",
+                        },
+                      ],
+                    },
+                  },
+                  Object {
+                    "@_name": "Dog",
+                    "xs:complexContent": Object {
+                      "xs:extension": Object {
+                        "@_base": "Animal",
+                        "xs:attribute": Object {
+                          "@_name": "registrationId",
+                          "@_type": "xs:string",
+                        },
+                        "xs:sequence": Object {
+                          "xs:element": Array [
+                            Object {
+                              "@_name": "breed",
+                              "@_type": "xs:string",
+                            },
+                            Object {
+                              "@_name": "trained",
+                              "@_type": "xs:boolean",
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                ],
+                "xs:element": Object {
+                  "@_name": "pet",
+                  "@_type": "Dog",
+                },
+              },
+            },
+          },
+          "propertyName": "age",
+          "required": true,
+        },
+        "name": ObjectPropertyModel {
+          "property": StringModel {
+            "name": "name",
+            "options": Object {},
+            "originalInput": Object {
+              "?xml": Object {
+                "@_encoding": "UTF-8",
+                "@_version": 1,
+              },
+              "xs:schema": Object {
+                "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                "xs:complexType": Array [
+                  Object {
+                    "@_name": "Animal",
+                    "xs:attribute": Object {
+                      "@_name": "species",
+                      "@_type": "xs:string",
+                      "@_use": "required",
+                    },
+                    "xs:sequence": Object {
+                      "xs:element": Array [
+                        Object {
+                          "@_name": "name",
+                          "@_type": "xs:string",
+                        },
+                        Object {
+                          "@_name": "age",
+                          "@_type": "xs:int",
+                        },
+                      ],
+                    },
+                  },
+                  Object {
+                    "@_name": "Dog",
+                    "xs:complexContent": Object {
+                      "xs:extension": Object {
+                        "@_base": "Animal",
+                        "xs:attribute": Object {
+                          "@_name": "registrationId",
+                          "@_type": "xs:string",
+                        },
+                        "xs:sequence": Object {
+                          "xs:element": Array [
+                            Object {
+                              "@_name": "breed",
+                              "@_type": "xs:string",
+                            },
+                            Object {
+                              "@_name": "trained",
+                              "@_type": "xs:boolean",
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                ],
+                "xs:element": Object {
+                  "@_name": "pet",
+                  "@_type": "Dog",
+                },
+              },
+            },
+          },
+          "propertyName": "name",
+          "required": true,
+        },
+        "species": ObjectPropertyModel {
+          "property": StringModel {
+            "name": "species",
+            "options": Object {},
+            "originalInput": Object {
+              "?xml": Object {
+                "@_encoding": "UTF-8",
+                "@_version": 1,
+              },
+              "xs:schema": Object {
+                "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                "xs:complexType": Array [
+                  Object {
+                    "@_name": "Animal",
+                    "xs:attribute": Object {
+                      "@_name": "species",
+                      "@_type": "xs:string",
+                      "@_use": "required",
+                    },
+                    "xs:sequence": Object {
+                      "xs:element": Array [
+                        Object {
+                          "@_name": "name",
+                          "@_type": "xs:string",
+                        },
+                        Object {
+                          "@_name": "age",
+                          "@_type": "xs:int",
+                        },
+                      ],
+                    },
+                  },
+                  Object {
+                    "@_name": "Dog",
+                    "xs:complexContent": Object {
+                      "xs:extension": Object {
+                        "@_base": "Animal",
+                        "xs:attribute": Object {
+                          "@_name": "registrationId",
+                          "@_type": "xs:string",
+                        },
+                        "xs:sequence": Object {
+                          "xs:element": Array [
+                            Object {
+                              "@_name": "breed",
+                              "@_type": "xs:string",
+                            },
+                            Object {
+                              "@_name": "trained",
+                              "@_type": "xs:boolean",
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                ],
+                "xs:element": Object {
+                  "@_name": "pet",
+                  "@_type": "Dog",
+                },
+              },
+            },
+          },
+          "propertyName": "species",
+          "required": true,
+        },
+      },
+    },
+    "Dog": ObjectModel {
+      "name": "Dog",
+      "options": Object {},
+      "originalInput": Object {
+        "?xml": Object {
+          "@_encoding": "UTF-8",
+          "@_version": 1,
+        },
+        "xs:schema": Object {
+          "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+          "xs:complexType": Array [
+            Object {
+              "@_name": "Animal",
+              "xs:attribute": Object {
+                "@_name": "species",
+                "@_type": "xs:string",
+                "@_use": "required",
+              },
+              "xs:sequence": Object {
+                "xs:element": Array [
+                  Object {
+                    "@_name": "name",
+                    "@_type": "xs:string",
+                  },
+                  Object {
+                    "@_name": "age",
+                    "@_type": "xs:int",
+                  },
+                ],
+              },
+            },
+            Object {
+              "@_name": "Dog",
+              "xs:complexContent": Object {
+                "xs:extension": Object {
+                  "@_base": "Animal",
+                  "xs:attribute": Object {
+                    "@_name": "registrationId",
+                    "@_type": "xs:string",
+                  },
+                  "xs:sequence": Object {
+                    "xs:element": Array [
+                      Object {
+                        "@_name": "breed",
+                        "@_type": "xs:string",
+                      },
+                      Object {
+                        "@_name": "trained",
+                        "@_type": "xs:boolean",
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+          "xs:element": Object {
+            "@_name": "pet",
+            "@_type": "Dog",
+          },
+        },
+      },
+      "properties": Object {
+        "breed": ObjectPropertyModel {
+          "property": StringModel {
+            "name": "breed",
+            "options": Object {},
+            "originalInput": Object {
+              "?xml": Object {
+                "@_encoding": "UTF-8",
+                "@_version": 1,
+              },
+              "xs:schema": Object {
+                "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                "xs:complexType": Array [
+                  Object {
+                    "@_name": "Animal",
+                    "xs:attribute": Object {
+                      "@_name": "species",
+                      "@_type": "xs:string",
+                      "@_use": "required",
+                    },
+                    "xs:sequence": Object {
+                      "xs:element": Array [
+                        Object {
+                          "@_name": "name",
+                          "@_type": "xs:string",
+                        },
+                        Object {
+                          "@_name": "age",
+                          "@_type": "xs:int",
+                        },
+                      ],
+                    },
+                  },
+                  Object {
+                    "@_name": "Dog",
+                    "xs:complexContent": Object {
+                      "xs:extension": Object {
+                        "@_base": "Animal",
+                        "xs:attribute": Object {
+                          "@_name": "registrationId",
+                          "@_type": "xs:string",
+                        },
+                        "xs:sequence": Object {
+                          "xs:element": Array [
+                            Object {
+                              "@_name": "breed",
+                              "@_type": "xs:string",
+                            },
+                            Object {
+                              "@_name": "trained",
+                              "@_type": "xs:boolean",
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                ],
+                "xs:element": Object {
+                  "@_name": "pet",
+                  "@_type": "Dog",
+                },
+              },
+            },
+          },
+          "propertyName": "breed",
+          "required": true,
+        },
+        "registrationId": ObjectPropertyModel {
+          "property": StringModel {
+            "name": "registrationId",
+            "options": Object {},
+            "originalInput": Object {
+              "?xml": Object {
+                "@_encoding": "UTF-8",
+                "@_version": 1,
+              },
+              "xs:schema": Object {
+                "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                "xs:complexType": Array [
+                  Object {
+                    "@_name": "Animal",
+                    "xs:attribute": Object {
+                      "@_name": "species",
+                      "@_type": "xs:string",
+                      "@_use": "required",
+                    },
+                    "xs:sequence": Object {
+                      "xs:element": Array [
+                        Object {
+                          "@_name": "name",
+                          "@_type": "xs:string",
+                        },
+                        Object {
+                          "@_name": "age",
+                          "@_type": "xs:int",
+                        },
+                      ],
+                    },
+                  },
+                  Object {
+                    "@_name": "Dog",
+                    "xs:complexContent": Object {
+                      "xs:extension": Object {
+                        "@_base": "Animal",
+                        "xs:attribute": Object {
+                          "@_name": "registrationId",
+                          "@_type": "xs:string",
+                        },
+                        "xs:sequence": Object {
+                          "xs:element": Array [
+                            Object {
+                              "@_name": "breed",
+                              "@_type": "xs:string",
+                            },
+                            Object {
+                              "@_name": "trained",
+                              "@_type": "xs:boolean",
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                ],
+                "xs:element": Object {
+                  "@_name": "pet",
+                  "@_type": "Dog",
+                },
+              },
+            },
+          },
+          "propertyName": "registrationId",
+          "required": false,
+        },
+        "trained": ObjectPropertyModel {
+          "property": BooleanModel {
+            "name": "trained",
+            "options": Object {},
+            "originalInput": Object {
+              "?xml": Object {
+                "@_encoding": "UTF-8",
+                "@_version": 1,
+              },
+              "xs:schema": Object {
+                "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                "xs:complexType": Array [
+                  Object {
+                    "@_name": "Animal",
+                    "xs:attribute": Object {
+                      "@_name": "species",
+                      "@_type": "xs:string",
+                      "@_use": "required",
+                    },
+                    "xs:sequence": Object {
+                      "xs:element": Array [
+                        Object {
+                          "@_name": "name",
+                          "@_type": "xs:string",
+                        },
+                        Object {
+                          "@_name": "age",
+                          "@_type": "xs:int",
+                        },
+                      ],
+                    },
+                  },
+                  Object {
+                    "@_name": "Dog",
+                    "xs:complexContent": Object {
+                      "xs:extension": Object {
+                        "@_base": "Animal",
+                        "xs:attribute": Object {
+                          "@_name": "registrationId",
+                          "@_type": "xs:string",
+                        },
+                        "xs:sequence": Object {
+                          "xs:element": Array [
+                            Object {
+                              "@_name": "breed",
+                              "@_type": "xs:string",
+                            },
+                            Object {
+                              "@_name": "trained",
+                              "@_type": "xs:boolean",
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                ],
+                "xs:element": Object {
+                  "@_name": "pet",
+                  "@_type": "Dog",
+                },
+              },
+            },
+          },
+          "propertyName": "trained",
+          "required": true,
+        },
+      },
+    },
+  },
+  "originalInput": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xs:schema xmlns:xs=\\"http://www.w3.org/2001/XMLSchema\\">
+  <!-- Base type -->
+  <xs:complexType name=\\"Animal\\">
+    <xs:sequence>
+      <xs:element name=\\"name\\" type=\\"xs:string\\"/>
+      <xs:element name=\\"age\\" type=\\"xs:int\\"/>
+    </xs:sequence>
+    <xs:attribute name=\\"species\\" type=\\"xs:string\\" use=\\"required\\"/>
+  </xs:complexType>
+
+  <!-- Extension via complexContent -->
+  <xs:complexType name=\\"Dog\\">
+    <xs:complexContent>
+      <xs:extension base=\\"Animal\\">
+        <xs:sequence>
+          <xs:element name=\\"breed\\" type=\\"xs:string\\"/>
+          <xs:element name=\\"trained\\" type=\\"xs:boolean\\"/>
+        </xs:sequence>
+        <xs:attribute name=\\"registrationId\\" type=\\"xs:string\\"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name=\\"pet\\" type=\\"Dog\\"/>
+</xs:schema>
+",
+}
+`;
+
+exports[`XsdInputProcessor inline simpleType within element should process XSD with inline simpleType in element 1`] = `
+InputMetaModel {
+  "models": Object {
+    "Product": ObjectModel {
+      "name": "Product",
+      "options": Object {},
+      "originalInput": Object {
+        "?xml": Object {
+          "@_encoding": "UTF-8",
+          "@_version": 1,
+        },
+        "xs:schema": Object {
+          "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+          "xs:element": Object {
+            "@_name": "Product",
+            "xs:complexType": Object {
+              "xs:sequence": Object {
+                "xs:element": Array [
+                  Object {
+                    "@_name": "status",
+                    "xs:simpleType": Object {
+                      "xs:restriction": Object {
+                        "@_base": "xs:string",
+                        "xs:enumeration": Array [
+                          Object {
+                            "@_value": "active",
+                          },
+                          Object {
+                            "@_value": "inactive",
+                          },
+                          Object {
+                            "@_value": "pending",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  Object {
+                    "@_name": "sku",
+                    "xs:simpleType": Object {
+                      "xs:restriction": Object {
+                        "@_base": "xs:string",
+                        "xs:pattern": Object {
+                          "@_value": "[A-Z]{3}-[0-9]{4}",
+                        },
+                      },
+                    },
+                  },
+                  Object {
+                    "@_name": "quantity",
+                    "@_type": "xs:int",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      "properties": Object {
+        "quantity": ObjectPropertyModel {
+          "property": IntegerModel {
+            "name": "quantity",
+            "options": Object {},
+            "originalInput": Object {
+              "?xml": Object {
+                "@_encoding": "UTF-8",
+                "@_version": 1,
+              },
+              "xs:schema": Object {
+                "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                "xs:element": Object {
+                  "@_name": "Product",
+                  "xs:complexType": Object {
+                    "xs:sequence": Object {
+                      "xs:element": Array [
+                        Object {
+                          "@_name": "status",
+                          "xs:simpleType": Object {
+                            "xs:restriction": Object {
+                              "@_base": "xs:string",
+                              "xs:enumeration": Array [
+                                Object {
+                                  "@_value": "active",
+                                },
+                                Object {
+                                  "@_value": "inactive",
+                                },
+                                Object {
+                                  "@_value": "pending",
+                                },
+                              ],
+                            },
+                          },
+                        },
+                        Object {
+                          "@_name": "sku",
+                          "xs:simpleType": Object {
+                            "xs:restriction": Object {
+                              "@_base": "xs:string",
+                              "xs:pattern": Object {
+                                "@_value": "[A-Z]{3}-[0-9]{4}",
+                              },
+                            },
+                          },
+                        },
+                        Object {
+                          "@_name": "quantity",
+                          "@_type": "xs:int",
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "propertyName": "quantity",
+          "required": true,
+        },
+        "sku": ObjectPropertyModel {
+          "property": StringModel {
+            "name": "sku",
+            "options": Object {},
+            "originalInput": Object {
+              "?xml": Object {
+                "@_encoding": "UTF-8",
+                "@_version": 1,
+              },
+              "xs:schema": Object {
+                "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                "xs:element": Object {
+                  "@_name": "Product",
+                  "xs:complexType": Object {
+                    "xs:sequence": Object {
+                      "xs:element": Array [
+                        Object {
+                          "@_name": "status",
+                          "xs:simpleType": Object {
+                            "xs:restriction": Object {
+                              "@_base": "xs:string",
+                              "xs:enumeration": Array [
+                                Object {
+                                  "@_value": "active",
+                                },
+                                Object {
+                                  "@_value": "inactive",
+                                },
+                                Object {
+                                  "@_value": "pending",
+                                },
+                              ],
+                            },
+                          },
+                        },
+                        Object {
+                          "@_name": "sku",
+                          "xs:simpleType": Object {
+                            "xs:restriction": Object {
+                              "@_base": "xs:string",
+                              "xs:pattern": Object {
+                                "@_value": "[A-Z]{3}-[0-9]{4}",
+                              },
+                            },
+                          },
+                        },
+                        Object {
+                          "@_name": "quantity",
+                          "@_type": "xs:int",
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "propertyName": "sku",
+          "required": true,
+        },
+        "status": ObjectPropertyModel {
+          "property": EnumModel {
+            "name": "status",
+            "options": Object {},
+            "originalInput": Object {
+              "?xml": Object {
+                "@_encoding": "UTF-8",
+                "@_version": 1,
+              },
+              "xs:schema": Object {
+                "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                "xs:element": Object {
+                  "@_name": "Product",
+                  "xs:complexType": Object {
+                    "xs:sequence": Object {
+                      "xs:element": Array [
+                        Object {
+                          "@_name": "status",
+                          "xs:simpleType": Object {
+                            "xs:restriction": Object {
+                              "@_base": "xs:string",
+                              "xs:enumeration": Array [
+                                Object {
+                                  "@_value": "active",
+                                },
+                                Object {
+                                  "@_value": "inactive",
+                                },
+                                Object {
+                                  "@_value": "pending",
+                                },
+                              ],
+                            },
+                          },
+                        },
+                        Object {
+                          "@_name": "sku",
+                          "xs:simpleType": Object {
+                            "xs:restriction": Object {
+                              "@_base": "xs:string",
+                              "xs:pattern": Object {
+                                "@_value": "[A-Z]{3}-[0-9]{4}",
+                              },
+                            },
+                          },
+                        },
+                        Object {
+                          "@_name": "quantity",
+                          "@_type": "xs:int",
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+            "values": Array [
+              EnumValueModel {
+                "key": "active",
+                "value": "active",
+              },
+              EnumValueModel {
+                "key": "inactive",
+                "value": "inactive",
+              },
+              EnumValueModel {
+                "key": "pending",
+                "value": "pending",
+              },
+            ],
+          },
+          "propertyName": "status",
+          "required": true,
+        },
+      },
+    },
+  },
+  "originalInput": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xs:schema xmlns:xs=\\"http://www.w3.org/2001/XMLSchema\\">
+  <!-- Element with inline simpleType -->
+  <xs:element name=\\"Product\\">
+    <xs:complexType>
+      <xs:sequence>
+        <!-- Inline simpleType on element -->
+        <xs:element name=\\"status\\">
+          <xs:simpleType>
+            <xs:restriction base=\\"xs:string\\">
+              <xs:enumeration value=\\"active\\"/>
+              <xs:enumeration value=\\"inactive\\"/>
+              <xs:enumeration value=\\"pending\\"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name=\\"sku\\">
+          <xs:simpleType>
+            <xs:restriction base=\\"xs:string\\">
+              <xs:pattern value=\\"[A-Z]{3}-[0-9]{4}\\"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name=\\"quantity\\" type=\\"xs:int\\"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+",
+}
+`;
+
 exports[`XsdInputProcessor process() should process XSD Schema with arrays (maxOccurs unbounded) 1`] = `
 InputMetaModel {
   "models": Object {
@@ -2439,6 +3293,758 @@ InputMetaModel {
   
 </xs:schema>
 
+",
+}
+`;
+
+exports[`XsdInputProcessor simpleContent parsing should process XSD with simpleContent extension 1`] = `
+InputMetaModel {
+  "models": Object {
+    "PersonType": ObjectModel {
+      "name": "PersonType",
+      "options": Object {},
+      "originalInput": Object {
+        "?xml": Object {
+          "@_encoding": "UTF-8",
+          "@_version": 1,
+        },
+        "xs:schema": Object {
+          "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+          "xs:complexType": Array [
+            Object {
+              "@_name": "PersonType",
+              "xs:simpleContent": Object {
+                "xs:extension": Object {
+                  "@_base": "xs:string",
+                  "xs:attribute": Array [
+                    Object {
+                      "@_name": "id",
+                      "@_type": "xs:int",
+                      "@_use": "required",
+                    },
+                    Object {
+                      "@_default": "en",
+                      "@_name": "lang",
+                      "@_type": "xs:string",
+                      "@_use": "optional",
+                    },
+                  ],
+                },
+              },
+            },
+            Object {
+              "@_name": "ShortString",
+              "xs:simpleContent": Object {
+                "xs:restriction": Object {
+                  "@_base": "xs:string",
+                  "xs:maxLength": Object {
+                    "@_value": 50,
+                  },
+                },
+              },
+            },
+          ],
+          "xs:element": Object {
+            "@_name": "Person",
+            "@_type": "PersonType",
+          },
+        },
+      },
+      "properties": Object {
+        "id": ObjectPropertyModel {
+          "property": IntegerModel {
+            "name": "id",
+            "options": Object {},
+            "originalInput": Object {
+              "?xml": Object {
+                "@_encoding": "UTF-8",
+                "@_version": 1,
+              },
+              "xs:schema": Object {
+                "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                "xs:complexType": Array [
+                  Object {
+                    "@_name": "PersonType",
+                    "xs:simpleContent": Object {
+                      "xs:extension": Object {
+                        "@_base": "xs:string",
+                        "xs:attribute": Array [
+                          Object {
+                            "@_name": "id",
+                            "@_type": "xs:int",
+                            "@_use": "required",
+                          },
+                          Object {
+                            "@_default": "en",
+                            "@_name": "lang",
+                            "@_type": "xs:string",
+                            "@_use": "optional",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  Object {
+                    "@_name": "ShortString",
+                    "xs:simpleContent": Object {
+                      "xs:restriction": Object {
+                        "@_base": "xs:string",
+                        "xs:maxLength": Object {
+                          "@_value": 50,
+                        },
+                      },
+                    },
+                  },
+                ],
+                "xs:element": Object {
+                  "@_name": "Person",
+                  "@_type": "PersonType",
+                },
+              },
+            },
+          },
+          "propertyName": "id",
+          "required": true,
+        },
+        "lang": ObjectPropertyModel {
+          "property": StringModel {
+            "name": "lang",
+            "options": Object {},
+            "originalInput": Object {
+              "?xml": Object {
+                "@_encoding": "UTF-8",
+                "@_version": 1,
+              },
+              "xs:schema": Object {
+                "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                "xs:complexType": Array [
+                  Object {
+                    "@_name": "PersonType",
+                    "xs:simpleContent": Object {
+                      "xs:extension": Object {
+                        "@_base": "xs:string",
+                        "xs:attribute": Array [
+                          Object {
+                            "@_name": "id",
+                            "@_type": "xs:int",
+                            "@_use": "required",
+                          },
+                          Object {
+                            "@_default": "en",
+                            "@_name": "lang",
+                            "@_type": "xs:string",
+                            "@_use": "optional",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  Object {
+                    "@_name": "ShortString",
+                    "xs:simpleContent": Object {
+                      "xs:restriction": Object {
+                        "@_base": "xs:string",
+                        "xs:maxLength": Object {
+                          "@_value": 50,
+                        },
+                      },
+                    },
+                  },
+                ],
+                "xs:element": Object {
+                  "@_name": "Person",
+                  "@_type": "PersonType",
+                },
+              },
+            },
+          },
+          "propertyName": "lang",
+          "required": false,
+        },
+        "value": ObjectPropertyModel {
+          "property": StringModel {
+            "name": "value",
+            "options": Object {},
+            "originalInput": Object {
+              "?xml": Object {
+                "@_encoding": "UTF-8",
+                "@_version": 1,
+              },
+              "xs:schema": Object {
+                "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+                "xs:complexType": Array [
+                  Object {
+                    "@_name": "PersonType",
+                    "xs:simpleContent": Object {
+                      "xs:extension": Object {
+                        "@_base": "xs:string",
+                        "xs:attribute": Array [
+                          Object {
+                            "@_name": "id",
+                            "@_type": "xs:int",
+                            "@_use": "required",
+                          },
+                          Object {
+                            "@_default": "en",
+                            "@_name": "lang",
+                            "@_type": "xs:string",
+                            "@_use": "optional",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  Object {
+                    "@_name": "ShortString",
+                    "xs:simpleContent": Object {
+                      "xs:restriction": Object {
+                        "@_base": "xs:string",
+                        "xs:maxLength": Object {
+                          "@_value": 50,
+                        },
+                      },
+                    },
+                  },
+                ],
+                "xs:element": Object {
+                  "@_name": "Person",
+                  "@_type": "PersonType",
+                },
+              },
+            },
+          },
+          "propertyName": "value",
+          "required": true,
+        },
+      },
+    },
+    "ShortString": ObjectModel {
+      "name": "ShortString",
+      "options": Object {},
+      "originalInput": Object {
+        "?xml": Object {
+          "@_encoding": "UTF-8",
+          "@_version": 1,
+        },
+        "xs:schema": Object {
+          "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+          "xs:complexType": Array [
+            Object {
+              "@_name": "PersonType",
+              "xs:simpleContent": Object {
+                "xs:extension": Object {
+                  "@_base": "xs:string",
+                  "xs:attribute": Array [
+                    Object {
+                      "@_name": "id",
+                      "@_type": "xs:int",
+                      "@_use": "required",
+                    },
+                    Object {
+                      "@_default": "en",
+                      "@_name": "lang",
+                      "@_type": "xs:string",
+                      "@_use": "optional",
+                    },
+                  ],
+                },
+              },
+            },
+            Object {
+              "@_name": "ShortString",
+              "xs:simpleContent": Object {
+                "xs:restriction": Object {
+                  "@_base": "xs:string",
+                  "xs:maxLength": Object {
+                    "@_value": 50,
+                  },
+                },
+              },
+            },
+          ],
+          "xs:element": Object {
+            "@_name": "Person",
+            "@_type": "PersonType",
+          },
+        },
+      },
+      "properties": Object {},
+    },
+  },
+  "originalInput": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xs:schema xmlns:xs=\\"http://www.w3.org/2001/XMLSchema\\">
+  <!-- ComplexType with simpleContent extension (adds an attribute to a base simple type) -->
+  <xs:complexType name=\\"PersonType\\">
+    <xs:simpleContent>
+      <xs:extension base=\\"xs:string\\">
+        <xs:attribute name=\\"id\\" type=\\"xs:int\\" use=\\"required\\"/>
+        <xs:attribute name=\\"lang\\" type=\\"xs:string\\" use=\\"optional\\" default=\\"en\\"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- ComplexType with simpleContent restriction -->
+  <xs:complexType name=\\"ShortString\\">
+    <xs:simpleContent>
+      <xs:restriction base=\\"xs:string\\">
+        <xs:maxLength value=\\"50\\"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name=\\"Person\\" type=\\"PersonType\\"/>
+</xs:schema>
+",
+}
+`;
+
+exports[`XsdInputProcessor simpleType constraint parsing should process XSD with pattern and length restrictions 1`] = `
+InputMetaModel {
+  "models": Object {
+    "EmailType": StringModel {
+      "name": "EmailType",
+      "options": Object {},
+      "originalInput": Object {
+        "?xml": Object {
+          "@_encoding": "UTF-8",
+          "@_version": 1,
+        },
+        "xs:schema": Object {
+          "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+          "xs:element": Array [
+            Object {
+              "@_name": "email",
+              "@_type": "EmailType",
+            },
+            Object {
+              "@_name": "password",
+              "@_type": "PasswordType",
+            },
+            Object {
+              "@_name": "percentage",
+              "@_type": "PercentageType",
+            },
+          ],
+          "xs:simpleType": Array [
+            Object {
+              "@_name": "EmailType",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:pattern": Object {
+                  "@_value": "[a-zA-Z0-9._%+\\\\-]+@[a-zA-Z0-9.\\\\-]+\\\\.[a-zA-Z]{2,}",
+                },
+              },
+            },
+            Object {
+              "@_name": "PasswordType",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:maxLength": Object {
+                  "@_value": 128,
+                },
+                "xs:minLength": Object {
+                  "@_value": 8,
+                },
+              },
+            },
+            Object {
+              "@_name": "PercentageType",
+              "xs:restriction": Object {
+                "@_base": "xs:decimal",
+                "xs:maxInclusive": Object {
+                  "@_value": 100,
+                },
+                "xs:minInclusive": Object {
+                  "@_value": 1,
+                },
+              },
+            },
+            Object {
+              "@_name": "NonEmptyString",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:minLength": Object {
+                  "@_value": 1,
+                },
+              },
+            },
+            Object {
+              "@_name": "ShortLabel",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:maxLength": Object {
+                  "@_value": 20,
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    "NonEmptyString": StringModel {
+      "name": "NonEmptyString",
+      "options": Object {},
+      "originalInput": Object {
+        "?xml": Object {
+          "@_encoding": "UTF-8",
+          "@_version": 1,
+        },
+        "xs:schema": Object {
+          "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+          "xs:element": Array [
+            Object {
+              "@_name": "email",
+              "@_type": "EmailType",
+            },
+            Object {
+              "@_name": "password",
+              "@_type": "PasswordType",
+            },
+            Object {
+              "@_name": "percentage",
+              "@_type": "PercentageType",
+            },
+          ],
+          "xs:simpleType": Array [
+            Object {
+              "@_name": "EmailType",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:pattern": Object {
+                  "@_value": "[a-zA-Z0-9._%+\\\\-]+@[a-zA-Z0-9.\\\\-]+\\\\.[a-zA-Z]{2,}",
+                },
+              },
+            },
+            Object {
+              "@_name": "PasswordType",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:maxLength": Object {
+                  "@_value": 128,
+                },
+                "xs:minLength": Object {
+                  "@_value": 8,
+                },
+              },
+            },
+            Object {
+              "@_name": "PercentageType",
+              "xs:restriction": Object {
+                "@_base": "xs:decimal",
+                "xs:maxInclusive": Object {
+                  "@_value": 100,
+                },
+                "xs:minInclusive": Object {
+                  "@_value": 1,
+                },
+              },
+            },
+            Object {
+              "@_name": "NonEmptyString",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:minLength": Object {
+                  "@_value": 1,
+                },
+              },
+            },
+            Object {
+              "@_name": "ShortLabel",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:maxLength": Object {
+                  "@_value": 20,
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    "PasswordType": StringModel {
+      "name": "PasswordType",
+      "options": Object {},
+      "originalInput": Object {
+        "?xml": Object {
+          "@_encoding": "UTF-8",
+          "@_version": 1,
+        },
+        "xs:schema": Object {
+          "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+          "xs:element": Array [
+            Object {
+              "@_name": "email",
+              "@_type": "EmailType",
+            },
+            Object {
+              "@_name": "password",
+              "@_type": "PasswordType",
+            },
+            Object {
+              "@_name": "percentage",
+              "@_type": "PercentageType",
+            },
+          ],
+          "xs:simpleType": Array [
+            Object {
+              "@_name": "EmailType",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:pattern": Object {
+                  "@_value": "[a-zA-Z0-9._%+\\\\-]+@[a-zA-Z0-9.\\\\-]+\\\\.[a-zA-Z]{2,}",
+                },
+              },
+            },
+            Object {
+              "@_name": "PasswordType",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:maxLength": Object {
+                  "@_value": 128,
+                },
+                "xs:minLength": Object {
+                  "@_value": 8,
+                },
+              },
+            },
+            Object {
+              "@_name": "PercentageType",
+              "xs:restriction": Object {
+                "@_base": "xs:decimal",
+                "xs:maxInclusive": Object {
+                  "@_value": 100,
+                },
+                "xs:minInclusive": Object {
+                  "@_value": 1,
+                },
+              },
+            },
+            Object {
+              "@_name": "NonEmptyString",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:minLength": Object {
+                  "@_value": 1,
+                },
+              },
+            },
+            Object {
+              "@_name": "ShortLabel",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:maxLength": Object {
+                  "@_value": 20,
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    "PercentageType": FloatModel {
+      "name": "PercentageType",
+      "options": Object {},
+      "originalInput": Object {
+        "?xml": Object {
+          "@_encoding": "UTF-8",
+          "@_version": 1,
+        },
+        "xs:schema": Object {
+          "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+          "xs:element": Array [
+            Object {
+              "@_name": "email",
+              "@_type": "EmailType",
+            },
+            Object {
+              "@_name": "password",
+              "@_type": "PasswordType",
+            },
+            Object {
+              "@_name": "percentage",
+              "@_type": "PercentageType",
+            },
+          ],
+          "xs:simpleType": Array [
+            Object {
+              "@_name": "EmailType",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:pattern": Object {
+                  "@_value": "[a-zA-Z0-9._%+\\\\-]+@[a-zA-Z0-9.\\\\-]+\\\\.[a-zA-Z]{2,}",
+                },
+              },
+            },
+            Object {
+              "@_name": "PasswordType",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:maxLength": Object {
+                  "@_value": 128,
+                },
+                "xs:minLength": Object {
+                  "@_value": 8,
+                },
+              },
+            },
+            Object {
+              "@_name": "PercentageType",
+              "xs:restriction": Object {
+                "@_base": "xs:decimal",
+                "xs:maxInclusive": Object {
+                  "@_value": 100,
+                },
+                "xs:minInclusive": Object {
+                  "@_value": 1,
+                },
+              },
+            },
+            Object {
+              "@_name": "NonEmptyString",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:minLength": Object {
+                  "@_value": 1,
+                },
+              },
+            },
+            Object {
+              "@_name": "ShortLabel",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:maxLength": Object {
+                  "@_value": 20,
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    "ShortLabel": StringModel {
+      "name": "ShortLabel",
+      "options": Object {},
+      "originalInput": Object {
+        "?xml": Object {
+          "@_encoding": "UTF-8",
+          "@_version": 1,
+        },
+        "xs:schema": Object {
+          "@_xmlns:xs": "http://www.w3.org/2001/XMLSchema",
+          "xs:element": Array [
+            Object {
+              "@_name": "email",
+              "@_type": "EmailType",
+            },
+            Object {
+              "@_name": "password",
+              "@_type": "PasswordType",
+            },
+            Object {
+              "@_name": "percentage",
+              "@_type": "PercentageType",
+            },
+          ],
+          "xs:simpleType": Array [
+            Object {
+              "@_name": "EmailType",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:pattern": Object {
+                  "@_value": "[a-zA-Z0-9._%+\\\\-]+@[a-zA-Z0-9.\\\\-]+\\\\.[a-zA-Z]{2,}",
+                },
+              },
+            },
+            Object {
+              "@_name": "PasswordType",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:maxLength": Object {
+                  "@_value": 128,
+                },
+                "xs:minLength": Object {
+                  "@_value": 8,
+                },
+              },
+            },
+            Object {
+              "@_name": "PercentageType",
+              "xs:restriction": Object {
+                "@_base": "xs:decimal",
+                "xs:maxInclusive": Object {
+                  "@_value": 100,
+                },
+                "xs:minInclusive": Object {
+                  "@_value": 1,
+                },
+              },
+            },
+            Object {
+              "@_name": "NonEmptyString",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:minLength": Object {
+                  "@_value": 1,
+                },
+              },
+            },
+            Object {
+              "@_name": "ShortLabel",
+              "xs:restriction": Object {
+                "@_base": "xs:string",
+                "xs:maxLength": Object {
+                  "@_value": 20,
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+  "originalInput": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<xs:schema xmlns:xs=\\"http://www.w3.org/2001/XMLSchema\\">
+  <!-- Pattern restriction -->
+  <xs:simpleType name=\\"EmailType\\">
+    <xs:restriction base=\\"xs:string\\">
+      <xs:pattern value=\\"[a-zA-Z0-9._%+\\\\-]+@[a-zA-Z0-9.\\\\-]+\\\\.[a-zA-Z]{2,}\\"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- minLength / maxLength restrictions -->
+  <xs:simpleType name=\\"PasswordType\\">
+    <xs:restriction base=\\"xs:string\\">
+      <xs:minLength value=\\"8\\"/>
+      <xs:maxLength value=\\"128\\"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Numeric range constraints -->
+  <xs:simpleType name=\\"PercentageType\\">
+    <xs:restriction base=\\"xs:decimal\\">
+      <xs:minInclusive value=\\"1\\"/>
+      <xs:maxInclusive value=\\"100\\"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- minLength only -->
+  <xs:simpleType name=\\"NonEmptyString\\">
+    <xs:restriction base=\\"xs:string\\">
+      <xs:minLength value=\\"1\\"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- maxLength only -->
+  <xs:simpleType name=\\"ShortLabel\\">
+    <xs:restriction base=\\"xs:string\\">
+      <xs:maxLength value=\\"20\\"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name=\\"email\\" type=\\"EmailType\\"/>
+  <xs:element name=\\"password\\" type=\\"PasswordType\\"/>
+  <xs:element name=\\"percentage\\" type=\\"PercentageType\\"/>
+</xs:schema>
 ",
 }
 `;


### PR DESCRIPTION
## Summary

Adds 20 new test cases to `test/processors/XsdInputProcessor.spec.ts` covering previously untested code paths identified in #2439.

**Previously uncovered paths now covered:**

- `parseSimpleContent` — complexType with `xs:simpleContent` extension (e.g., `PersonType` with base string + attributes)
- `parseComplexContent` — complexType with `xs:complexContent` extension including `xs:sequence` and attributes (`Dog extends Animal`)
- `parseSimpleType` within elements — inline `xs:simpleType` restriction on element children
- Pattern restrictions — `xs:pattern` on `xs:simpleType`
- Length constraints — `xs:minLength` only, `xs:maxLength` only, and both together
- Numeric constraints — `xs:minInclusive` only, `xs:maxInclusive` only, and both together
- `XsdSchema.toSchema` edge cases — empty object input, schema `targetNamespace`/`elementFormDefault`/`attributeFormDefault`

**New XSD fixture files:**

| File | Purpose |
|------|---------|
| `simple-content.xsd` | `PersonType` using `xs:simpleContent` with extension + attribute |
| `complex-content.xsd` | `Dog` extending `Animal` via `xs:complexContent` extension |
| `pattern-restrictions.xsd` | `EmailType`, `PasswordType`, `PercentageType`, `NonEmptyString`, `ShortLabel` |
| `inline-simple-type.xsd` | `Product` element with inline `xs:simpleType` restriction on child elements |

**Test count:** 34 total (was 14), all passing.

**Snapshots:** 4 new snapshots added, 1 updated.

Closes #2439

🤖 Generated with [Claude Code](https://claude.com/claude-code)

/claim #2439