### PR TITLE
fix: handle nullable property in OpenAPI 3.0 schemas

### DIFF
--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -142,6 +142,10 @@ export class Interpreter {
     if (schema.type !== undefined) {
       model.addTypes(schema.type);
     }
+    // Handle nullable property from OpenAPI 3.0.x schemas
+    if ('nullable' in schema && schema.nullable === true) {
+      model.addTypes('null');
+    }
     if (schema.required !== undefined) {
       model.required = schema.required;
     }

--- a/test/interpreter/unit/Interpreter.spec.ts
+++ b/test/interpreter/unit/Interpreter.spec.ts
@@ -322,4 +322,65 @@ describe('Interpreter', () => {
     expect(model2).not.toBeUndefined();
     expect(model1).not.toBe(model2);
   });
+  describe('nullable', () => {
+    test('should add null type for OpenAPI 3.0 schema with nullable: true', () => {
+      const schema = OpenapiV3Schema.toSchema({
+        type: 'string',
+        nullable: true
+      });
+      const interpreter = new Interpreter();
+      const model = interpreter.interpret(schema);
+      expect(model).not.toBeUndefined();
+      expect(model?.type).toEqual(['string', 'null']);
+    });
+    test('should not add null type when nullable is false', () => {
+      const schema = OpenapiV3Schema.toSchema({
+        type: 'string',
+        nullable: false
+      });
+      const interpreter = new Interpreter();
+      const model = interpreter.interpret(schema);
+      expect(model).not.toBeUndefined();
+      expect(model?.type).toEqual('string');
+    });
+    test('should not add null type when nullable is not present', () => {
+      const schema = OpenapiV3Schema.toSchema({
+        type: 'string'
+      });
+      const interpreter = new Interpreter();
+      const model = interpreter.interpret(schema);
+      expect(model).not.toBeUndefined();
+      expect(model?.type).toEqual('string');
+    });
+    test('should not duplicate null type if already present', () => {
+      const schema = OpenapiV3Schema.toSchema({
+        type: ['string', 'null'],
+        nullable: true
+      });
+      const interpreter = new Interpreter();
+      const model = interpreter.interpret(schema);
+      expect(model).not.toBeUndefined();
+      expect(model?.type).toEqual(['string', 'null']);
+    });
+    test('should handle nullable on object type', () => {
+      const schema = OpenapiV3Schema.toSchema({
+        type: 'object',
+        nullable: true
+      });
+      const interpreter = new Interpreter();
+      const model = interpreter.interpret(schema);
+      expect(model).not.toBeUndefined();
+      expect(model?.type).toEqual(['object', 'null']);
+    });
+    test('should handle nullable on integer type', () => {
+      const schema = OpenapiV3Schema.toSchema({
+        type: 'integer',
+        nullable: true
+      });
+      const interpreter = new Interpreter();
+      const model = interpreter.interpret(schema);
+      expect(model).not.toBeUndefined();
+      expect(model?.type).toEqual(['integer', 'null']);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes #2488

The `Interpreter.interpretSchemaObject` method did not check for the `nullable: true` property on OpenAPI 3.0.x schemas. This caused `isNullable` to never be set for properties using the `nullable` keyword, resulting in generated model types missing the `| null` union type.

### Root Cause

In OpenAPI 3.0.x, nullable types are expressed via `nullable: true` on the schema object (as opposed to JSON Schema's `type: ["string", "null"]` pattern). The Interpreter handles `schema.type` but never checked for `schema.nullable`, so the `'null'` type was never added to the `CommonModel.type` array. Downstream, `CommonModelToMetaModel.getMetaModelOptions` checks for `'null'` in the type array to set `isNullable`, so these properties were incorrectly generated as non-nullable.

### Fix

Added a check in `interpretSchemaObject` that detects `nullable: true` on any schema type (using `'nullable' in schema`) and calls `model.addTypes('null')`. The `addTypes` method already deduplicates, so if `'null'` is already present (e.g., from `type: ["string", "null"]`), it won't be added twice.

### Before (incorrect)

```yaml
visaToken:
  type: string
  nullable: true
```

```ts
export interface ServerEventsSubscriptionPayload {
  visaToken?: string;  // missing | null
}
```

### After (correct)

```ts
export interface ServerEventsSubscriptionPayload {
  visaToken?: string | null;
}
```

## Testing

Added 6 unit tests covering:
- `nullable: true` adds null type (string, object, integer)
- `nullable: false` does not add null type
- Missing `nullable` does not add null type
- `nullable: true` with `type: ["string", "null"]` does not duplicate null

All 122 interpreter tests pass. Existing snapshot tests (asyncapi-openapi-schema, csharp-handle-nullable) unaffected.

/claim #2488