### PR TITLE
fix(interpreter): apply nullable types to isNullable

### DIFF
--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -142,6 +142,9 @@ export class Interpreter {
     if (schema.type !== undefined) {
       model.addTypes(schema.type);
     }
+    if (schema.nullable === true) {
+      model.addTypes('null');
+    }
     if (schema.required !== undefined) {
       model.required = schema.required;
     }

--- a/test/interpreter/unit/Interpreter.spec.ts
+++ b/test/interpreter/unit/Interpreter.spec.ts
@@ -313,6 +313,35 @@ describe('Interpreter', () => {
       expect(discriminator).toBe('OpenapiV3SchemaDiscriminatorPropertyName');
     });
   });
+  test('should interpret nullable schema and add null type', () => {
+    const schema = {
+      type: 'string',
+      nullable: true
+    };
+    const interpreter = new Interpreter();
+    const model = interpreter.interpret(schema);
+    expect(model).not.toBeUndefined();
+    expect(model?.type).toEqual(['string', 'null']);
+  });
+  test('should not add null type when nullable is false', () => {
+    const schema = {
+      type: 'string',
+      nullable: false
+    };
+    const interpreter = new Interpreter();
+    const model = interpreter.interpret(schema);
+    expect(model).not.toBeUndefined();
+    expect(model?.type).toEqual('string');
+  });
+  test('should not add null type when nullable is not set', () => {
+    const schema = {
+      type: 'string'
+    };
+    const interpreter = new Interpreter();
+    const model = interpreter.interpret(schema);
+    expect(model).not.toBeUndefined();
+    expect(model?.type).toEqual('string');
+  });
   test('should not use cache if disableCache is set', () => {
     const schema = { type: 'object' };
     const interpreter = new Interpreter();


### PR DESCRIPTION
Fixes #2488

The `interpretSchemaObject` method in Interpreter.ts was not checking for the `nullable` property on schemas. This meant that schemas with `nullable: true` would not have `null` added to their type array, and consequently `isNullable` would not be set to true in the MetaModel conversion.

**Changes:**
- Add a check for `schema.nullable === true` in `interpretSchemaObject` that calls `model.addTypes('null')`
- Add 3 unit tests covering: nullable=true adds null type, nullable=false does not, and absent nullable does not

**How to verify:**
- Run `npx jest test/interpreter/unit/Interpreter.spec.ts` — all 28 tests pass
- Generate TypeScript models from an AsyncAPI spec with `nullable: true` properties and confirm `| null` appears in output