### PR TITLE
fix(python): properly escape quotes in Pydantic const default values

### DIFF
--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -7,6 +7,10 @@ import { ClassPresetType, PythonPreset } from '../PythonPreset';
 
 function formatPythonConstValue(constValue: unknown): string {
   if (typeof constValue === 'string') {
+    if (constValue.includes("'")) {
+      // Use double quotes when value contains single quotes to avoid escaping issues
+      return `"${constValue.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+    }
     return `'${constValue}'`;
   }
   if (typeof constValue === 'boolean') {

--- a/test/generators/python/presets/Pydantic.spec.ts
+++ b/test/generators/python/presets/Pydantic.spec.ts
@@ -225,4 +225,35 @@ describe('PYTHON_PYDANTIC_PRESET', () => {
     const models = await generator.generate(doc);
     expect(models.map((model) => model.result)).toMatchSnapshot();
   });
+
+  test('should properly escape quotes in const string values', async () => {
+    const doc = {
+      title: 'ConstEscapeTest',
+      type: 'object',
+      properties: {
+        withSingleQuote: {
+          type: 'string',
+          const: "it's a test"
+        },
+        withDoubleQuote: {
+          type: 'string',
+          const: 'say "hello"'
+        },
+        normalString: {
+          type: 'string',
+          const: 'normal'
+        }
+      },
+      required: ['withSingleQuote', 'withDoubleQuote', 'normalString']
+    };
+
+    const models = await generator.generate(doc);
+    const output = models[0].result;
+    // Should use double quotes when value contains single quotes
+    expect(output).toContain('Literal["it\'s a test"]');
+    expect(output).toContain('default="it\'s a test"');
+    // Normal strings should still use single quotes
+    expect(output).toContain("Literal['normal']");
+    expect(output).toContain("default='normal'");
+  });
 });


### PR DESCRIPTION
Fixes #2474

When a `const` string value contains single quotes (e.g., `it's`), the generated Pydantic field produces invalid Python syntax like `Literal['it's a test']` because the inner quotes are not escaped.

**Changes:**
- Update `formatPythonConstValue()` in Pydantic.ts to detect single quotes in string values and use double quotes as the outer delimiter instead, with proper escaping of backslashes and double quotes
- Add test case covering const values with single quotes, double quotes, and normal strings

**How to verify:**
- `npx jest test/generators/python/presets/Pydantic.spec.ts` — all 7 tests pass
- Generate Pydantic models from a schema with `const: "it's test"` and verify valid Python output